### PR TITLE
PowerShell Graph SDK v2.x changes

### DIFF
--- a/AOSPEnrollmentProfileManagement/AOSP_Token_Renew_Export.ps1
+++ b/AOSPEnrollmentProfileManagement/AOSP_Token_Renew_Export.ps1
@@ -12,7 +12,9 @@ https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powers
 #>
 
 # Get and display all AOSP enrollment profiles
-$EnrollmentProfiles = Get-MgBetaDeviceManagementAndroidDeviceOwnerEnrollmentProfile -Filter "enrollmentMode eq 'corporateOwnedAOSPUserAssociatedDevice' or enrollmentMode eq 'corporateOwnedAOSPUserlessDevice'" -Property "Id, displayName, enrollmentMode, tokenValue, tokenCreationDateTime,tokenExpirationDateTime, qrCodeContent" 
+$EnrollmentProfiles = Get-MgBetaDeviceManagementAndroidDeviceOwnerEnrollmentProfile -Property "Id, displayName, enrollmentMode, tokenValue, tokenCreationDateTime,tokenExpirationDateTime, qrCodeContent" 
+# Select only the AOSP enrollment profiles
+$EnrollmentProfiles = $EnrollmentProfiles | Where-Object { $_.enrollmentMode -eq "corporateOwnedAOSPUserAssociatedDevice" -or $_.enrollmentMode -eq "corporateOwnedAOSPUserlessDevice"}
 $EnrollmentProfiles | Select-Object -Property "Id", "displayName", "EnrollmentMode", "tokenCreationDateTime", "tokenExpirationDateTime" | Format-Table -AutoSize
 
 # If there are no AOSP enrollment profiles, exit

--- a/AndroidEnterprise/Get-AndroidDedicatedDeviceQRCode.ps1
+++ b/AndroidEnterprise/Get-AndroidDedicatedDeviceQRCode.ps1
@@ -1,4 +1,4 @@
-Import-Module Microsoft.Graph.DeviceManagement.Enrolment
+Import-Module Microsoft.Graph.Beta.DeviceManagement.Enrollment
 
 <# region Authentication
 To authenticate, you'll use the Microsoft Graph PowerShell SDK. If you haven't already installed the SDK, see this guide:
@@ -9,10 +9,6 @@ https://learn.microsoft.com/powershell/microsoftgraph/get-started?view=graph-pow
 For details on using app-only access for unattended scenarios, see Use app-only authentication with the Microsoft Graph PowerShell SDK:
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
-
-# using beta endpoint for this sample as it is not yet available in v1.0
-$Version = "beta"
-Select-MgProfile -Name $Version
 
 # get the path to save the QR code image
 Write-Host
@@ -41,7 +37,7 @@ if (!(Test-Path "$ExportPath")) {
 }
 
 # Get all Android dedicated device profiles
-$EnrollmentProfiles = Get-MgDeviceManagementAndroidDeviceOwnerEnrollmentProfile -Filter "EnrollmentMode eq 'corporateOwnedDedicatedDevice'"
+$EnrollmentProfiles = Get-MgBetaDeviceManagementAndroidDeviceOwnerEnrollmentProfile -Filter "EnrollmentMode eq 'corporateOwnedDedicatedDevice'"
 $EnrollmentProfiles | Format-Table -AutoSize
 Write-Host
 
@@ -74,7 +70,7 @@ $confirmExport = Read-Host "Do you want to continue? (Y/N)"
 # If user confirms, export the QR code
 switch ($confirmExport) {
     "Y" {
-        $QR = Get-MgDeviceManagementAndroidDeviceOwnerEnrollmentProfile -AndroidDeviceOwnerEnrollmentProfileId $AndroidDeviceOwnerEnrollmentProfileId -Select qrCodeImage
+        $QR = Get-MgBetaDeviceManagementAndroidDeviceOwnerEnrollmentProfile -AndroidDeviceOwnerEnrollmentProfileId $AndroidDeviceOwnerEnrollmentProfileId -Select qrCodeImage
         $QRType = $QR.qrCodeImage.type
         $QRValue = $QR.qrCodeImage.value
         

--- a/AndroidEnterprise/Get-AndroidDeviceOwnerProfiles.ps1
+++ b/AndroidEnterprise/Get-AndroidDeviceOwnerProfiles.ps1
@@ -1,4 +1,4 @@
-Import-Module Microsoft.Graph.DeviceManagement.Enrolment
+Import-Module Microsoft.Graph.Beta.DeviceManagement.Enrollment
 
 <# region Authentication
 To authenticate, you'll use the Microsoft Graph PowerShell SDK. If you haven't already installed the SDK, see this guide:
@@ -10,11 +10,8 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-# using beta endpoint for this sample as it is not yet available in v1.0
-Select-MgProfile -Name beta
-
 # Get all Android device profiles
-Get-MgDeviceManagementAndroidDeviceOwnerEnrollmentProfile | Format-Table -AutoSize
+Get-MgBetaDeviceManagementAndroidDeviceOwnerEnrollmentProfile | Format-Table -AutoSize
 
 # Get all Android dedicated device profiles
 #Get-MgDeviceManagementAndroidDeviceOwnerEnrollmentProfile -Filter "EnrollmentMode eq 'corporateOwnedDedicatedDevice'" | Format-Table -AutoSize

--- a/AndroidEnterprise/Get-AndroidWorkProfileConfiguration.ps1
+++ b/AndroidEnterprise/Get-AndroidWorkProfileConfiguration.ps1
@@ -1,4 +1,4 @@
-Import-Module Microsoft.Graph.DeviceManagement.Enrolment
+Import-Module Microsoft.Graph.Beta.DeviceManagement.Enrollment
 
 <# region Authentication
 To authenticate, you'll use the Microsoft Graph PowerShell SDK. If you haven't already installed the SDK, see this guide:
@@ -10,12 +10,8 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-# Required Graph beta endpoint, some calls not yet available in v1.0
-$Version = "beta"
-Select-MgProfile -Name $Version
-
 # Getting all Platform Enrollment Restrictions
-$PlatformRestrictions = Get-MgDeviceManagementDeviceEnrollmentConfiguration -Filter ("DeviceEnrollmentConfigurationType eq 'singlePlatformRestriction'")
+$PlatformRestrictions = Get-MgBetaDeviceManagementDeviceEnrollmentConfiguration -Filter ("DeviceEnrollmentConfigurationType eq 'singlePlatformRestriction'")
 
 foreach ($Policy in $PlatformRestrictions) {
     Write-Host
@@ -31,7 +27,7 @@ foreach ($Policy in $PlatformRestrictions) {
     elseif ($Policy.Id.Contains("SinglePlatformRestriction") -and $Policy.AdditionalProperties.platformType.Contains("androidForWork")) {
         Write-Host $Policy.DisplayName
         Write-Host 'Priority:'$Policy.Priority''
-        $Assignments = Get-MgDeviceManagementDeviceEnrollmentConfigurationAssignment -DeviceEnrollmentConfigurationId $Policy.Id
+        $Assignments = Get-MgBetaDeviceManagementDeviceEnrollmentConfigurationAssignment -DeviceEnrollmentConfigurationId $Policy.Id
 
         Write-Host "Android Enterprise restrictions: " 
         $Policy.AdditionalProperties.platformRestriction | Format-Table -HideTableHeaders

--- a/AppConfigurationPolicy/AppConfigurationPolicy_Export.ps1
+++ b/AppConfigurationPolicy/AppConfigurationPolicy_Export.ps1
@@ -13,7 +13,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-Select-MgProfile -Name v1.0
 
 # Managed device app configuration policies (MDM channel)
 $ManagedDeviceAppConfigPolicies = Get-MgDeviceAppManagementMobileAppConfiguration -Property Id, DisplayName, Description

--- a/AppConfigurationPolicy/AppConfigurationPolicy_ImportFromJSON.ps1
+++ b/AppConfigurationPolicy/AppConfigurationPolicy_ImportFromJSON.ps1
@@ -14,8 +14,6 @@ https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powers
 
 #>
 
-Select-MgProfile -Name v1.0
-
 $AppConfigSelection = Read-Host -Prompt "What type of app configuration policy will be imported?
 (Enter '1' for Managed Device or '2' for Managed App)"  
 

--- a/AppProtectionPolicy/ManagedAppPolicy_Add.ps1
+++ b/AppProtectionPolicy/ManagedAppPolicy_Add.ps1
@@ -14,8 +14,6 @@ https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powers
 
 #>
 
-Select-MgProfile -Name v1.0
-
 # Define the apps to be included in the policy
 $Apps = @(
 	@{

--- a/AppProtectionPolicy/ManagedAppPolicy_Add_Assign.ps1
+++ b/AppProtectionPolicy/ManagedAppPolicy_Add_Assign.ps1
@@ -14,8 +14,6 @@ https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powers
 
 #>
 
-Select-MgProfile -Name v1.0
-
 # Set the AAD Group where the policy will be assigned
 $AADGroup = Read-Host -Prompt "Enter the Azure AD Group name where policies will be assigned"
 $SelectedGroup = (Get-MgGroup -Filter "DisplayName eq '$AADGroup'")

--- a/AppProtectionPolicy/ManagedAppPolicy_AppRegistrationSummary.ps1
+++ b/AppProtectionPolicy/ManagedAppPolicy_AppRegistrationSummary.ps1
@@ -13,8 +13,6 @@ https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powers
 
 #>
 
-Select-MgProfile -Name v1.0
-
 Write-Host
 $ExportPath = Read-Host -Prompt "Please specify a path to export the policy data to e.g. C:\IntuneOutput"
 

--- a/AppProtectionPolicy/ManagedAppPolicy_Export.ps1
+++ b/AppProtectionPolicy/ManagedAppPolicy_Export.ps1
@@ -14,8 +14,6 @@ https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powers
 
 #>
 
-Select-MgProfile -Name v1.0
-
 # Using get-mgdeviceappmanagementandroid/iosmanagedappprotection rather than get-mgdeviceappmanagementmanagedapppolicy to filter out app configuration policies
 $AndroidPolicies = Get-MgDeviceAppManagementAndroidManagedAppProtection -Property Id, DisplayName, Description
 $iOSPolicies = Get-MgDeviceAppManagementiOSManagedAppProtection -Property Id, DisplayName, Description

--- a/AppProtectionPolicy/ManagedAppPolicy_Get.ps1
+++ b/AppProtectionPolicy/ManagedAppPolicy_Get.ps1
@@ -14,8 +14,6 @@ https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powers
 
 #>
 
-Select-MgProfile -Name v1.0
-
 # Using get-mgdeviceappmanagementandroid/iosmanagedappprotection rather than get-mgdeviceappmanagementmanagedapppolicy to filter out app configuration policies
 $AndroidPolicies = Get-MgDeviceAppManagementAndroidManagedAppProtection -Property Id, DisplayName, Description
 $iOSPolicies = Get-MgDeviceAppManagementiOSManagedAppProtection -Property Id, DisplayName, Description

--- a/AppProtectionPolicy/ManagedAppPolicy_Import_From_JSON.ps1
+++ b/AppProtectionPolicy/ManagedAppPolicy_Import_From_JSON.ps1
@@ -13,9 +13,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-# Selecting Graph v1.0
-Select-MgProfile -Name v1.0
-
 $ImportPath = Read-Host -Prompt "Please specify a path to a JSON file to import data from e.g. C:\IntuneOutput\Policies\policy.json"
 
 # Replacing quotes for Test-Path

--- a/AppProtectionPolicy/ManagedAppPolicy_MobileAppIdentifier_Get.ps1
+++ b/AppProtectionPolicy/ManagedAppPolicy_MobileAppIdentifier_Get.ps1
@@ -11,7 +11,6 @@ https://learn.microsoft.com/powershell/microsoftgraph/get-started?view=graph-pow
 For details on using app-only access for unattended scenarios, see Use app-only authentication with the Microsoft Graph PowerShell SDK:
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
-Select-MgProfile -Name v1.0
 
 #Using get-mgdeviceappmanagementandroid/iosmanagedappprotection rather than get-mgdeviceappmanagementmanagedapppolicy to filter out app configuration policies
 $androidPolicies = Get-MgDeviceAppManagementAndroidManagedAppProtection -Property Id

--- a/AppProtectionPolicy/ManagedAppPolicy_Wipe.ps1
+++ b/AppProtectionPolicy/ManagedAppPolicy_Wipe.ps1
@@ -22,9 +22,6 @@ https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powers
 
 #>
 
-# Setting graph endpoint to v1.0
-Select-MgProfile -Name v1.0
-
 # Get the user's ID from UPN
 $UserUPN = Read-Host "Enter the UPN of the user"
 

--- a/AppleEnrollment/ADEProfile_Assign.ps1
+++ b/AppleEnrollment/ADEProfile_Assign.ps1
@@ -1,5 +1,5 @@
-Import-Module Microsoft.Graph.DeviceManagement.Enrolment
-Import-Module Microsoft.Graph.DeviceManagement.Actions
+Import-Module Microsoft.Graph.Beta.DeviceManagement.Enrollment
+Import-Module Microsoft.Graph.Beta.DeviceManagement.Actions
 
 <# region Authentication
 To authenticate, you'll use the Microsoft Graph PowerShell SDK. If you haven't already installed the SDK, see this guide:
@@ -11,10 +11,8 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-# Get-MgDeviceManagementDepOnboardingSetting not yet available in v1.0, using beta endpoint
-Select-MgProfile -Name beta
-
-$ADETokens = Get-MgDeviceManagementDepOnboardingSetting
+# Retrieve ADE (DEP) tokens
+$ADETokens = Get-MgBetaDeviceManagementDepOnboardingSetting
 
 if ($ADETokens.Count -eq 0) {
     Write-Host "No ADE tokens found."
@@ -34,7 +32,7 @@ if ($ADETokenId -eq $null -or $ADETokenId -notin $ADETokens.Id) {
     break
 }
 
-$EnrollmentProfiles = Get-MgDeviceManagementDepOnboardingSettingEnrollmentProfile -DepOnboardingSettingId $ADETokenId 
+$EnrollmentProfiles = Get-MgBetaDeviceManagementDepOnboardingSettingEnrollmentProfile -DepOnboardingSettingId $ADETokenId 
 $EnrollmentProfiles | Select-Object DisplayName, Id | Format-Table -AutoSize
 
 $EnrollmentProfileToAssign = Read-Host "Please enter the enrollment profile ID to assign to the device and press enter"
@@ -45,7 +43,7 @@ if (($EnrollmentProfileToAssign -eq $null) -or ($EnrollmentProfileToAssign -noti
 }
 else {
     $DeviceSerialNumber = Read-Host "Please enter the device serial number you want to assign the enrollment profile to and press enter"
-    Update-MgDeviceManagementDepOnboardingSettingEnrollmentProfileDeviceProfileAssignment -DepOnboardingSettingId $ADETokenId -EnrollmentProfileId $EnrollmentProfileToAssign -DeviceIds $DeviceSerialNumber 
+    Update-MgBetaDeviceManagementDepOnboardingSettingEnrollmentProfileDeviceProfileAssignment -DepOnboardingSettingId $ADETokenId -EnrollmentProfileId $EnrollmentProfileToAssign -DeviceIds $DeviceSerialNumber 
     if ($?) {
         Write-Host "Enrollment profile $EnrollmentProfileToAssign assigned successfully to $DeviceSerialNumber." -ForegroundColor Green
     }

--- a/AppleEnrollment/ADEProfile_Assign_CSV.ps1
+++ b/AppleEnrollment/ADEProfile_Assign_CSV.ps1
@@ -1,5 +1,5 @@
-Import-Module Microsoft.Graph.DeviceManagement.Enrolment
-Import-Module Microsoft.Graph.DeviceManagement.Actions
+Import-Module Microsoft.Graph.Beta.DeviceManagement.Enrollment
+Import-Module Microsoft.Graph.Beta.DeviceManagement.Actions
 
 <# region Authentication
 To authenticate, you'll use the Microsoft Graph PowerShell SDK. If you haven't already installed the SDK, see this guide:
@@ -11,11 +11,8 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-# Get-MgDeviceManagementDepOnboardingSetting not yet available in v1.0, using beta endpoint
-Select-MgProfile -Name beta
-
 # Retrieve ADE (DEP) tokens
-$ADETokens = Get-MgDeviceManagementDepOnboardingSetting
+$ADETokens = Get-MgBetaDeviceManagementDepOnboardingSetting
 
 if ($ADETokens.Count -eq 0) {
     Write-Host "No ADE tokens found."
@@ -36,7 +33,7 @@ if ($ADETokenId -eq $null -or $ADETokenId -notin $ADETokens.Id) {
 }
 
 # Retrieve enrollment profiles associated with the ADE token
-$EnrollmentProfiles = Get-MgDeviceManagementDepOnboardingSettingEnrollmentProfile -DepOnboardingSettingId $ADETokenId 
+$EnrollmentProfiles = Get-MgBetaDeviceManagementDepOnboardingSettingEnrollmentProfile -DepOnboardingSettingId $ADETokenId 
 $EnrollmentProfiles | Select-Object DisplayName, Id | Format-Table -AutoSize
 
 $EnrollmentProfileToAssign = Read-Host "Please enter the enrollment profile ID to assign to the device and press enter"
@@ -71,7 +68,7 @@ else {
 
     #Performing enrollment profile assignment
     If ($ConfirmAssign -match "[yY]") { 
-        Update-MgDeviceManagementDepOnboardingSettingEnrollmentProfileDeviceProfileAssignment -DepOnboardingSettingId $ADETokenId  -EnrollmentProfileId $EnrollmentProfileToAssign -DeviceIds $Serials.deviceIds
+        Update-MgBetaDeviceManagementDepOnboardingSettingEnrollmentProfileDeviceProfileAssignment -DepOnboardingSettingId $ADETokenId  -EnrollmentProfileId $EnrollmentProfileToAssign -DeviceIds $Serials.deviceIds
         if ($?) {
             Write-Host "Enrollment profile $EnrollmentProfileToAssign successfully assigned  to $DeviceCount devices." -ForegroundColor Green
         }

--- a/AppleEnrollment/ADE_Sync.ps1
+++ b/AppleEnrollment/ADE_Sync.ps1
@@ -1,5 +1,5 @@
-Import-Module Microsoft.Graph.DeviceManagement.Enrolment
-Import-Module Microsoft.Graph.DeviceManagement.Actions
+Import-Module Microsoft.Graph.Beta.DeviceManagement.Enrollment
+Import-Module Microsoft.Graph.Beta.DeviceManagement.Actions
 
 
 <# region Authentication
@@ -12,10 +12,7 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-# Get-MgDeviceManagementDepOnboardingSetting not yet available in v1.0, using beta endpoint
-Select-MgProfile -Name beta
-
-$ADETokens = Get-MgDeviceManagementDepOnboardingSetting
+$ADETokens = Get-MgBetaDeviceManagementDepOnboardingSetting
 
 if ($ADETokens.Count -eq 0) {
     Write-Host "No ADE tokens found."
@@ -30,6 +27,4 @@ elseif ($ADETokens.Count -gt 1) {
     $ADETokenId = Read-Host "More than one ADE token found. Please enter the token ID to sync and press enter"
 }
 
-Sync-MgDeviceManagementDepOnboardingSettingWithAppleDeviceEnrollmentProgram -DepOnboardingSettingId $ADETokenId
-
-
+Sync-MgBetaDeviceManagementDepOnboardingSettingWithAppleDeviceEnrollmentProgram -DepOnboardingSettingId $ADETokenId

--- a/AppleEnrollment/APNS_Get.ps1
+++ b/AppleEnrollment/APNS_Get.ps1
@@ -10,6 +10,4 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-Select-MgProfile -Name v1.0
-
 Get-MgDeviceManagementApplePushNotificationCertificate

--- a/ApplicationSync/ManagedGooglePlay_Sync.ps1
+++ b/ApplicationSync/ManagedGooglePlay_Sync.ps1
@@ -1,4 +1,4 @@
-Import-Module Microsoft.Graph.DeviceManagement.Actions
+Import-Module Microsoft.Graph.Beta.DeviceManagement.Actions
 
 <# region Authentication
 To authenticate, you'll use the Microsoft Graph PowerShell SDK. If you haven't already installed the SDK, see this guide:
@@ -10,15 +10,12 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-# MGP cmdlets used not yet available in v1.0, using beta endpoint
-Select-MgProfile -Name beta
-
-$MGP = Get-MgDeviceManagementAndroidManagedStoreAccountEnterpriseSetting
+$MGP = Get-MgBetaDeviceManagementAndroidManagedStoreAccountEnterpriseSetting
 
 if ($MGP.BindStatus -ne "boundAndValidated") {
     Write-Host "Managed Google Play is not bound to this tenant. Exiting..." -ForegroundColor Red
     return
 }
 else {
-    Sync-MgDeviceManagementAndroidManagedStoreAccountEnterpriseSettingApp
+    Sync-MgBetaDeviceManagementAndroidManagedStoreAccountEnterpriseSettingApp
 }

--- a/ApplicationSync/Sync-AppleVPP.ps1
+++ b/ApplicationSync/Sync-AppleVPP.ps1
@@ -10,9 +10,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-# Select v1.0 endpoint
-Select-MgProfile -Name v1.0
-
 # Get VPP tokens
 $VPPTokens = Get-MgDeviceAppManagementVppToken
 $VPPTokens | Format-Table -AutoSize

--- a/DeviceConfiguration/DeviceConfiguration_Add.ps1
+++ b/DeviceConfiguration/DeviceConfiguration_Add.ps1
@@ -14,9 +14,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal
 
 #>
-
-Select-MgProfile -Name v1.0
-Connect-MgGraph -Scopes "DeviceManagementConfiguration.ReadWrite.All"
 #endregion
 
 ####################################################

--- a/DeviceConfiguration/DeviceConfiguration_Add_Assign.ps1
+++ b/DeviceConfiguration/DeviceConfiguration_Add_Assign.ps1
@@ -1,7 +1,6 @@
 Import-Module Microsoft.Graph.DeviceManagement
 
 ####################################################
-
 <# region Authentication
 To authenticate, you'll use the Microsoft Graph PowerShell SDK. If you haven't already installed the SDK, see this guide:
 https://learn.microsoft.com/en-us/powershell/microsoftgraph/installation?view=graph-powershell-1.0
@@ -15,9 +14,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal
 
 #>
-
-Select-MgProfile -Name v1.0
-Connect-MgGraph -Scopes "DeviceManagementConfiguration.ReadWrite.All"
 #endregion
 ####################################################
 

--- a/DeviceConfiguration/DeviceConfiguration_Export.ps1
+++ b/DeviceConfiguration/DeviceConfiguration_Export.ps1
@@ -15,9 +15,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal
 
 #>
-
-Select-MgProfile -Name v1.0
-Connect-MgGraph -Scopes "DeviceManagementConfiguration.ReadWrite.All"
 #endregion
 
 ####################################################

--- a/DeviceConfiguration/DeviceConfiguration_Get.ps1
+++ b/DeviceConfiguration/DeviceConfiguration_Get.ps1
@@ -16,8 +16,6 @@ https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powers
 
 #>
 
-Select-MgProfile -Name v1.0
-Connect-MgGraph -Scopes "DeviceManagementConfiguration.ReadWrite.All"
 #endregion
 
 ####################################################

--- a/DeviceConfiguration/DeviceConfiguration_Get_Assign.ps1
+++ b/DeviceConfiguration/DeviceConfiguration_Get_Assign.ps1
@@ -15,9 +15,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal
 
 #>
-
-Select-MgProfile -Name v1.0
-Connect-MgGraph -Scopes "DeviceManagementConfiguration.ReadWrite.All"
 #endregion
 
 ####################################################

--- a/DeviceConfiguration/DeviceConfiguration_Import_FromJSON.ps1
+++ b/DeviceConfiguration/DeviceConfiguration_Import_FromJSON.ps1
@@ -16,8 +16,6 @@ https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powers
 
 #>
 
-Select-MgProfile -Name v1.0
-Connect-MgGraph -Scopes "DeviceManagementConfiguration.ReadWrite.All"
 #endregion
 
 ####################################################

--- a/DeviceConfiguration/DeviceConfiguration_Remove.ps1
+++ b/DeviceConfiguration/DeviceConfiguration_Remove.ps1
@@ -23,8 +23,6 @@ https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powers
 
 #>
 
-Select-MgProfile -Name v1.0
-Connect-MgGraph -Scopes "DeviceManagementConfiguration.ReadWrite.All"
 #endregion
 
 ####################################################

--- a/DeviceConfiguration/DeviceManagementScript_Add.ps1
+++ b/DeviceConfiguration/DeviceManagementScript_Add.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module Microsoft.Graph.DeviceManagement
+﻿Import-Module Microsoft.Graph.Beta.DeviceManagement
 
 ####################################################
 
@@ -15,9 +15,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal
 
 #>
-
-Select-MgProfile -Name beta
-Connect-MgGraph -Scopes "DeviceManagementConfiguration.ReadWrite.All"
 #endregion
 ####################################################
 
@@ -27,4 +24,4 @@ $ScriptName = "Test script"
 $ScriptPath = "C:\Scripts\test-script.ps1"
 
 # Upload new Intune script
-New-MgDeviceManagementScript -DisplayName $ScriptName -ScriptContentInputFile $ScriptPath -Description $ScriptDescription
+New-MgBetaDeviceManagementScript -DisplayName $ScriptName -ScriptContentInputFile $ScriptPath -Description $ScriptDescription

--- a/DeviceConfiguration/DeviceManagementScripts_Get.ps1
+++ b/DeviceConfiguration/DeviceManagementScripts_Get.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module Microsoft.Graph.DeviceManagement
+﻿Import-Module Microsoft.Graph.Beta.DeviceManagement
 
 ####################################################
 
@@ -15,13 +15,12 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal
 
 #>
-Select-MgProfile -Name beta
-Connect-MgGraph -Scopes "DeviceManagementConfiguration.ReadWrite.All"
+
 #endregion
 ####################################################
 
 
-$PSScripts = Get-mgdeviceManagementScript
+$PSScripts = Get-MgBetaDeviceManagementScript
 
 if ($PSScripts) {
 
@@ -39,7 +38,7 @@ if ($PSScripts) {
 
         write-host "Device Management Scripts - Assignments" -f Cyan
 
-        $Assignments = Get-MgDeviceManagementScriptAssignment -DeviceManagementScriptId $_.Id
+        $Assignments = Get-MgBetaDeviceManagementScriptAssignment -DeviceManagementScriptId $_.Id
 
         if ($Assignments) {
 
@@ -61,7 +60,7 @@ if ($PSScripts) {
 
         }
 
-        $Script = Get-mgdeviceManagementScript -DeviceManagementScriptId $ScriptId
+        $Script = Get-MgBetaDeviceManagementScript -DeviceManagementScriptId $ScriptId
 
         $ScriptContent = $Script.scriptContent
 

--- a/Filters/IntuneFilter_Export.ps1
+++ b/Filters/IntuneFilter_Export.ps1
@@ -4,7 +4,7 @@ Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT
 See LICENSE in the project root for license information.
 #>
 
-Import-Module Microsoft.Graph.Devices.CorporateManagement
+Import-Module Microsoft.Graph.Beta.Devices.CorporateManagement
 
 <# region Authentication
 To authenticate, you'll use the Microsoft Graph PowerShell SDK. If you haven't already installed the SDK, see this guide:

--- a/Filters/IntuneFilter_Get.ps1
+++ b/Filters/IntuneFilter_Get.ps1
@@ -4,7 +4,7 @@ Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT
 See LICENSE in the project root for license information.
 #>
 
-Import-Module Microsoft.Graph.Devices.CorporateManagement
+Import-Module Microsoft.Graph.Beta.Devices.CorporateManagement
 
 <# region Authentication
 To authenticate, you'll use the Microsoft Graph PowerShell SDK. If you haven't already installed the SDK, see this guide:

--- a/LOB_Application/iOS_Application_LOB_App.ps1
+++ b/LOB_Application/iOS_Application_LOB_App.ps1
@@ -10,9 +10,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-$version = "v1.0"
-Select-MgProfile -Name $version
-
 #Path for temp copies of extracted .ipa files
 $ExtractedPath = Join-Path -Path $env:TEMP -ChildPath ([System.IO.Path]::GetRandomFileName())
 

--- a/ManagedDevices/ManagedDeviceOverview_Get.ps1
+++ b/ManagedDevices/ManagedDeviceOverview_Get.ps1
@@ -10,8 +10,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-Select-MgProfile -Name v1.0
-
 # Using Invoke-MgGraphRequest instead of Get-MgDeviceManagementManagedDeviceOverview as it contains more OS information
 $Overview = Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/beta/deviceManagement/managedDeviceOverview" -Method GET -ContentType "application/json" 
 

--- a/ManagedDevices/ManagedDevices_Add_ToAADGroup.ps1
+++ b/ManagedDevices/ManagedDevices_Add_ToAADGroup.ps1
@@ -15,8 +15,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-Select-MgProfile "v1.0"
-
 #Filter Intune devices by UPN
 $UPN = Read-Host -Prompt "Enter the UPN of the user whose device will be added to the group"
 $Devices = Get-MgDeviceManagementManagedDevice -Filter "UserPrincipalName eq '$UPN'"  | Select-Object  ManagedDeviceName, Id, DeviceName, Manufacturer, AzureAdDeviceId, UserPrincipalName, UserId

--- a/ManagedDevices/ManagedDevices_Apps_Get.ps1
+++ b/ManagedDevices/ManagedDevices_Apps_Get.ps1
@@ -13,6 +13,4 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-Select-MgProfile -Name "v1.0"
-
 Get-MgDeviceManagementDetectedApp -All

--- a/ManagedDevices/ManagedDevices_DeviceOwnership_Set.ps1
+++ b/ManagedDevices/ManagedDevices_DeviceOwnership_Set.ps1
@@ -13,8 +13,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-Select-MgProfile -Name "v1.0"
-
 # Uncomment the line below to return a list of all Intune managed devices
 # Get-MgUserManagedDevice -All
 

--- a/ManagedDevices/ManagedDevices_Get.ps1
+++ b/ManagedDevices/ManagedDevices_Get.ps1
@@ -13,8 +13,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-Select-MgProfile -Name "v1.0"
-
 #Retrieve all managed devices
 Get-MgDeviceManagementManagedDevice -All
 

--- a/ManagedDevices/ManagedDevices_Hardware_Get.ps1
+++ b/ManagedDevices/ManagedDevices_Hardware_Get.ps1
@@ -13,8 +13,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-Select-MgProfile -Name "beta"
-
 $ExportPath = Read-Host -Prompt "Please specify a path to export the hardware information .csv file e.g. C:\IntuneOutput"
 
 # If the directory path doesn't exist prompt user to create the directory

--- a/ManagedDevices/ManagedDevices_iOS_PasscodeReset_Export.ps1
+++ b/ManagedDevices/ManagedDevices_iOS_PasscodeReset_Export.ps1
@@ -13,8 +13,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-Select-MgProfile -Name v1.0
-
 $DownloadPath = Read-Host -Prompt "Enter full path to download and store the .zip, .csv, and .json files"
 if (-not (Test-Path $DownloadPath)) {
     Write-Output "Path does not exist. Creating directory $DownloadPath"

--- a/ManagedDevices/Win_PrimaryUser_Delete.ps1
+++ b/ManagedDevices/Win_PrimaryUser_Delete.ps1
@@ -13,8 +13,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-Select-MgProfile -Name v1.0
-
 $DeviceName = Read-Host -Prompt "Enter the device name to search for"
 $Devices = Get-MgDeviceManagementManagedDevice -Filter "DeviceName eq '$DeviceName'" | Select-Object  DeviceName, Id, userPrincipalName, UserId
 if ($null -eq $Devices) {

--- a/ManagedDevices/Win_PrimaryUser_Get.ps1
+++ b/ManagedDevices/Win_PrimaryUser_Get.ps1
@@ -13,8 +13,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-Select-MgProfile -Name v1.0
-
 #Search for enrolled device by name
 $DeviceName = Read-Host -Prompt "Enter the device name to search for"
 $Devices = Get-MgDeviceManagementManagedDevice -Filter "DeviceName eq '$DeviceName'"

--- a/ManagedDevices/Win_PrimaryUser_Set.ps1
+++ b/ManagedDevices/Win_PrimaryUser_Set.ps1
@@ -13,8 +13,6 @@ For details on using app-only access for unattended scenarios, see Use app-only 
 https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal 
 #>
 
-Select-MgProfile -Name v1.0
-
 #Search for enrolled device by name
 $DeviceName = Read-Host -Prompt "Enter the device name to search for"
 $Devices = Get-MgDeviceManagementManagedDevice -Filter "DeviceName eq '$DeviceName'" | Select-Object  DeviceName, Id, userPrincipalName, UserId

--- a/SettingsCatalog/SettingsCatalog_Export.ps1
+++ b/SettingsCatalog/SettingsCatalog_Export.ps1
@@ -1,4 +1,4 @@
-Import-Module Microsoft.Graph.DeviceManagement
+Import-Module Microsoft.Graph.Beta.DeviceManagement
 
 <# region Authentication
 To authenticate, you'll use the Microsoft Graph PowerShell SDK. If you haven't already installed the SDK, see this guide:


### PR DESCRIPTION
This pull request includes changes across several PowerShell scripts used for device management.
- Removed Select-MgProfile cmdlet from all scripts as v2.x of the PowerShell Graph SDK defaults to the v1.0 endpoints
- For scripts using the beta Graph endpoints, changed the module import lines to the equivalent Microsoft.Graph.Beta submodules.
- For scripts using the beta Graph endpoints, converted the equivalent cmdlets to the Beta versions (E.G. Get-MgUser to Get-MgBetaUser)

Changes to module import:

* `AndroidEnterprise/Get-AndroidDedicatedDeviceQRCode.ps1`, `AndroidEnterprise/Get-AndroidDeviceOwnerProfiles.ps1`, `AndroidEnterprise/Get-AndroidWorkProfileConfiguration.ps1`, `AppleEnrollment/ADEProfile_Assign.ps1`, `AppleEnrollment/ADEProfile_Assign_CSV.ps1`, `AppleEnrollment/ADE_Sync.ps1`: Updated the import statements to use the beta version of the `Microsoft.Graph.DeviceManagement.Enrollment` and `Microsoft.Graph.DeviceManagement.Actions` modules instead of the stable version. [[1]](diffhunk://#diff-328c6b288e2532b4fb33efa114e9f3c3382072e0ba9b89d296e8649daf74f9edL1-R1) [[2]](diffhunk://#diff-3ebc33c5ae9f327a1441f440b1bc233fa0ec7881878ab0578292424cf4acb66fL1-R1) [[3]](diffhunk://#diff-780db499899f481956ef5a46d0e7a152e73fe8344bd7b21c19546aedc76081eaL1-R1) [[4]](diffhunk://#diff-7ebd3019e82e924775ce8c6c8cac287038c4cc04b72ba019eabbab88cb24b633L1-R2) [[5]](diffhunk://#diff-b4ecd0885e708b131e5b39f3e8e03fd2cba6bdb3d9913a0c27c0a73eb97b15e7L1-R2) [[6]](diffhunk://#diff-a6b03546edb4bfcb6ce52860920beb80476a2d02b629bc53c444d7d9da0eff24L1-R2)

Changes to function usage:

* [`AOSPEnrollmentProfileManagement/AOSP_Token_Renew_Export.ps1`](diffhunk://#diff-0ee33b970ba82115a882c4509590087aaa17fd8c0261426480251bb195d3f14fL15-R17): Modified the `Get-MgBetaDeviceManagementAndroidDeviceOwnerEnrollmentProfile` function to fetch all enrollment profiles and then filter the AOSP enrollment profiles, instead of using the `-Filter` parameter.
* `AndroidEnterprise/Get-AndroidDedicatedDeviceQRCode.ps1`, `AndroidEnterprise/Get-AndroidDeviceOwnerProfiles.ps1`, `AndroidEnterprise/Get-AndroidWorkProfileConfiguration.ps1`, `AppleEnrollment/ADEProfile_Assign.ps1`, `AppleEnrollment/ADEProfile_Assign_CSV.ps1`: Updated the usage of various functions to use the beta version instead of the stable version. [[1]](diffhunk://#diff-328c6b288e2532b4fb33efa114e9f3c3382072e0ba9b89d296e8649daf74f9edL13-L16) [[2]](diffhunk://#diff-328c6b288e2532b4fb33efa114e9f3c3382072e0ba9b89d296e8649daf74f9edL44-R40) [[3]](diffhunk://#diff-328c6b288e2532b4fb33efa114e9f3c3382072e0ba9b89d296e8649daf74f9edL77-R73) [[4]](diffhunk://#diff-3ebc33c5ae9f327a1441f440b1bc233fa0ec7881878ab0578292424cf4acb66fL13-R14) [[5]](diffhunk://#diff-780db499899f481956ef5a46d0e7a152e73fe8344bd7b21c19546aedc76081eaL13-R14) [[6]](diffhunk://#diff-780db499899f481956ef5a46d0e7a152e73fe8344bd7b21c19546aedc76081eaL34-R30) [[7]](diffhunk://#diff-7ebd3019e82e924775ce8c6c8cac287038c4cc04b72ba019eabbab88cb24b633L14-R15) [[8]](diffhunk://#diff-7ebd3019e82e924775ce8c6c8cac287038c4cc04b72ba019eabbab88cb24b633L37-R35) [[9]](diffhunk://#diff-7ebd3019e82e924775ce8c6c8cac287038c4cc04b72ba019eabbab88cb24b633L48-R46) [[10]](diffhunk://#diff-b4ecd0885e708b131e5b39f3e8e03fd2cba6bdb3d9913a0c27c0a73eb97b15e7L14-R15) [[11]](diffhunk://#diff-b4ecd0885e708b131e5b39f3e8e03fd2cba6bdb3d9913a0c27c0a73eb97b15e7L39-R36) [[12]](diffhunk://#diff-b4ecd0885e708b131e5b39f3e8e03fd2cba6bdb3d9913a0c27c0a73eb97b15e7L74-R71)

Removal of explicit Graph profile selection:

* `AppConfigurationPolicy/AppConfigurationPolicy_Export.ps1`, `AppConfigurationPolicy/AppConfigurationPolicy_ImportFromJSON.ps1`, `AppProtectionPolicy/ManagedAppPolicy_Add.ps1`, `AppProtectionPolicy/ManagedAppPolicy_Add_Assign.ps1`, `AppProtectionPolicy/ManagedAppPolicy_AppRegistrationSummary.ps1`, `AppProtectionPolicy/ManagedAppPolicy_Export.ps1`, `AppProtectionPolicy/ManagedAppPolicy_Get.ps1`, `AppProtectionPolicy/ManagedAppPolicy_Import_From_JSON.ps1`, `AppProtectionPolicy/ManagedAppPolicy_MobileAppIdentifier_Get.ps1`, `AppProtectionPolicy/ManagedAppPolicy_Wipe.ps1`, `AppleEnrollment/ADEProfile_Assign.ps1`, `AppleEnrollment/ADEProfile_Assign_CSV.ps1`: Removed the explicit selection of the Graph profile using `Select-MgProfile`. [[1]](diffhunk://#diff-35da3295ab1929547c7d64f540f687d3abd9d252958a0e4e6b7597691224416dL16) [[2]](diffhunk://#diff-525dfb05f825ab294acf500f286164ab2c5a2a1e991fe5b3eda31bc88bf0b402L17-L18) [[3]](diffhunk://#diff-c564c3a920f4f522e840ba049d1c731d2fc960429eeaddc6469d9f6c68e622e8L17-L18) [[4]](diffhunk://#diff-77219cd58bb086caaffa2873ad05929548e70bf25e07165aec512d3503261fe1L17-L18) [[5]](diffhunk://#diff-e7dd37ae7b540e479a9ab173184419508bb737b1e532f99c08f287fa47d37cdeL16-L17) [[6]](diffhunk://#diff-0e09ca3ded3a5964928a6714ebbcdf673ac61524aee06244e106f0b7e46bb99bL17-L18) [[7]](diffhunk://#diff-7305e6e14940c8c56b116ae1635b2d5ee33365d63e0a9e29b07488f4633a6afeL17-L18) [[8]](diffhunk://#diff-39eab8e37ac5ed45e2f30e8deb28866b265ec337417ed6d80fd33990fa46d27cL16-L18) [[9]](diffhunk://#diff-2c679ccc0050248cfe43e812334e51335455e0f460b293c4509b5e9d693135cfL14) [[10]](diffhunk://#diff-0ef898ea94c53e55a5361b23979c86de9deca1f59bdcaa987d15e6d48eb82707L25-L27) [[11]](diffhunk://#diff-7ebd3019e82e924775ce8c6c8cac287038c4cc04b72ba019eabbab88cb24b633L14-R15) [[12]](diffhunk://#diff-b4ecd0885e708b131e5b39f3e8e03fd2cba6bdb3d9913a0c27c0a73eb97b15e7L14-R15)