### PR TITLE
Add files via upload

### DIFF
--- a/AppProtectionPolicy/ManagedAppPolicy_Export.ps1
+++ b/AppProtectionPolicy/ManagedAppPolicy_Export.ps1
@@ -19,7 +19,7 @@ $AndroidPolicies = Get-MgDeviceAppManagementAndroidManagedAppProtection -Propert
 $iOSPolicies = Get-MgDeviceAppManagementiOSManagedAppProtection -Property Id, DisplayName, Description
 
 if ($AndroidPolicies.Length -eq 0 -and $iOSPolicies.Length -eq 0) {
-    Write-Host "No policies found" -ForegroundColor Red
+    Write-Host "No policies found" -ForegroundColor Yellow
     break
 }
 
@@ -29,13 +29,10 @@ $AndroidPolicies | Format-Table -Property Id, DisplayName, Description
 Write-Host "iOS Policies:"
 $iOSPolicies | Format-Table -Property Id, DisplayName, Description
 
-Write-Host
 $ExportPath = Read-Host -Prompt "Please specify a path to export each policy's JSON file to e.g. C:\IntuneOutput"
 
 # If the directory path doesn't exist prompt user to create the directory
 if (!(Test-Path "$ExportPath")) {
-    
-    Write-Host
     Write-Host "Path '$ExportPath' doesn't exist, do you want to create this directory? Y or N?" -ForegroundColor Yellow
 
     $Confirm = Read-Host
@@ -55,38 +52,37 @@ if (!(Test-Path "$ExportPath")) {
 }
 
 #Loop through each Android policy and export the JSON file
-Write-Host "Exporting Android policies..." -ForegroundColor Green
-Write-Host
-foreach ($Policy in $AndroidPolicies.Id) {
+Write-Host "Exporting Android policies..."
+foreach ($Policy in $AndroidPolicies) {
+    $Uri = "https://graph.microsoft.com/beta/deviceAppManagement/androidManagedAppProtections('$($Policy.Id)')" + '?$expand=apps'
+    $ExportedFilePath = "$ExportPath\ManagedAppPolicy_$($Policy.DisplayName)_$($Policy.Id).json"
     try {
-        $Policy = Get-MgDeviceAppManagementAndroidManagedAppProtection -AndroidManagedAppProtectionId $Policy
+        $PolicyBody = Invoke-MgGraphRequest -Method GET -Uri $Uri -ContentType JSON -OutputFilePath "$ExportPath\ManagedAppPolicy_$($Policy.DisplayName)_$($Policy.Id).json"
     }
     catch {
-        Write-Host "An error occurred while retrieving the Managed App Policy with the id '$Id', please provide a valid policy id..." -f Red
+        Write-Host "An error occurred while retrieving the Managed App Policy with the id $Policy.Id, please provide a valid policy id..." -f Red
         break
     }
-    $Policy | ConvertTo-Json -Depth 10 | Out-File "$ExportPath\ManagedAppPolicy_$($Policy.DisplayName)_$($Policy.Id).json"
     if ($? -eq $true) {
-        Write-Host "JSON file created and can be found at $ExportPath\ManagedAppPolicy_$($Policy.DisplayName)_$($Policy.Id).json" -ForegroundColor Green
+        Write-Host "JSON file created: $ExportedFilePath" -ForegroundColor Green
     }
 }
 
 Write-Host
-Write-Host "Exporting iOS policies..." -ForegroundColor Green
-Write-Host
+Write-Host "Exporting iOS policies..." 
 
 #Loop through each iOS policy and export the JSON file
-foreach ($Policy in $iOSPolicies.Id) {
+foreach ($Policy in $iOSPolicies) {
+    $ExportedFilePath = "$ExportPath\ManagedAppPolicy_$($Policy.DisplayName)_$($Policy.Id).json"
+    $Uri = "https://graph.microsoft.com/beta/deviceAppManagement/iosManagedAppProtections('$($Policy.Id)')" + '?$expand=apps'
     try {
-        $Policy = Get-MgDeviceAppManagementiOSManagedAppProtection -IosManagedAppProtectionId $Policy
+        $PolicyBody = Invoke-MgGraphRequest -Method GET -Uri $Uri -ContentType JSON -OutputFilePath "$ExportPath\ManagedAppPolicy_$($Policy.DisplayName)_$($Policy.Id).json"
     }
     catch {
         Write-Host "An error occurred while retrieving the Managed App Policy with the id '$Id', please provide a valid policy id..." -f Red
-        Write-Host
         break
     }
-    $Policy | ConvertTo-Json -Depth 10 | Out-File "$ExportPath\ManagedAppPolicy_$($Policy.DisplayName)_$($Policy.Id).json"
     if ($? -eq $true) {
-        Write-Host "JSON file created and can be found at $ExportPath\ManagedAppPolicy_$($Policy.DisplayName)_$($Policy.Id).json" -ForegroundColor Green
+        Write-Host "JSON file created: $ExportedFilePath" -ForegroundColor Green
     }
 }


### PR DESCRIPTION
This pull request introduces a few changes to the `AppProtectionPolicy/ManagedAppPolicy_Export.ps1` and `AppProtectionPolicy/ManagedAppPolicy_Import_From_JSON.ps1` files. The changes include formatting/code readability and improvements to the handling and validation of JSON data during import and export.

JSON Handling and Validation:

* [`AppProtectionPolicy/ManagedAppPolicy_Export.ps1`](diffhunk://#diff-0e09ca3ded3a5964928a6714ebbcdf673ac61524aee06244e106f0b7e46bb99bL58-R86): The script now iterates over the full `AndroidPolicies` and `iOSPolicies` objects instead of just their `Id` properties. It also uses `Invoke-MgGraphRequest` to retrieve policy data and directly writes the response to a JSON file, simplifying the process and reducing the risk of errors. This should resolve #5 

* [`AppProtectionPolicy/ManagedAppPolicy_Import_From_JSON.ps1`](diffhunk://#diff-39eab8e37ac5ed45e2f30e8deb28866b265ec337417ed6d80fd33990fa46d27cL16-R93): The script now distinguishes between iOS and Android policies and creates the appropriate policy accordingly. It also includes improved error handling and provides more informative error messages.