### PR TITLE
iOS_Application_LOB_App.ps1 bug fixes

### DIFF
--- a/LOB_Application/iOS_Application_LOB_App.ps1
+++ b/LOB_Application/iOS_Application_LOB_App.ps1
@@ -14,7 +14,7 @@ https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powers
 $ExtractedPath = Join-Path -Path $env:TEMP -ChildPath ([System.IO.Path]::GetRandomFileName())
 
 #Base URL for Graph API calls
-$baseUrl = "https://graph.microsoft.com/$version/deviceAppManagement/"
+$baseUrl = "https://graph.microsoft.com/v1.0/deviceAppManagement/"
 
 $sleep = 30
 

--- a/LOB_Application/iOS_Application_LOB_App.ps1
+++ b/LOB_Application/iOS_Application_LOB_App.ps1
@@ -554,4 +554,4 @@ function Invoke-iOSLobAppUpload() {
 }
 
 ## Example
-#Invoke-iOSLobAppUpload -SourceFile "C:\IntuneApps\MyLobApp.ipa" -displayName "A test application to deploy via Intune" -Publisher "Contoso" -Description "A test application to deploy via Intune."
+#Invoke-iOSLobAppUpload -SourceFile ".\MyLobApp.ipa" -displayName "A test application to deploy via Intune" -Publisher "Contoso" -Description "A test application to deploy via Intune."

--- a/LOB_Application/readme.md
+++ b/LOB_Application/readme.md
@@ -47,12 +47,12 @@ https://learn.microsoft.com/en-us/powershell/microsoftgraph/get-started?view=gra
 2. To upload an iOS LOB app into your tenant, run the ```Invoke-iOSLobAppUpload``` function specifying the .ipa path (```-SourceFile```), Intune Display Name (```-displayName```), Publisher (```-publisher```), and description (```-Description```)
 
 ```PowerShell
-Invoke-iOSLobAppUpload -SourceFile "C:\IntuneApps\MyLobApp.ipa" -displayName "My Test LOB App" -Publisher "Contoso" -Description "A test iOS app to upload."
+Invoke-iOSLobAppUpload -SourceFile ".\MyLobApp.ipa" -displayName "My Test LOB App" -Publisher "Contoso" -Description "A test iOS app to upload."
 ```
 ```
 Creating JSON data to pass to the service...
 ```
-Note: If the script is unable to extract and parse these values from the app payload (for example, the app payload is obfuscated or signed), it prompts for them to be entered manually.
+Note: If the script is unable to extract and parse these values from the app payload (for example, the app payload is obfuscated or signed), it prompts for them to be entered manually. The .IPA file must be in the same folder path the script is executed from.
 ```
 Unable to extract the app's bundleId (CFBundleIdentifier). Please enter it manually: com.contoso.test       
 Unable to extract the app's buildNumber (CFBundleVersion). Please enter it manually: 1.23045.11 


### PR DESCRIPTION
This pull request includes changes to two files: `LOB_Application/iOS_Application_LOB_App.ps1` and `LOB_Application/readme.md`. The changes are primarily focused on updating the base URL for Graph API calls and modifying the path for the `Invoke-iOSLobAppUpload` function in the PowerShell script and the corresponding documentation.

Here are the key changes:

Updates to the PowerShell script (`LOB_Application/iOS_Application_LOB_App.ps1`):

* The base URL for Graph API calls was updated from a variable `$version` to a fixed version `v1.0`.
* The `Invoke-iOSLobAppUpload` function example was updated to indicate that the source file is in the current directory instead of an absolute path.

Updates to the documentation (`LOB_Application/readme.md`):

* The example usage of `Invoke-iOSLobAppUpload` was updated to reflect the change in the PowerShell script, indicating that the .ipa file should be in the same directory as the script.