### PR TITLE
fix: replace undefined $JSON_Data with $JsonPolicyBody in line 50

### DIFF
--- a/DeviceConfiguration/DeviceConfiguration_Import_FromJSON.ps1
+++ b/DeviceConfiguration/DeviceConfiguration_Import_FromJSON.ps1
@@ -47,7 +47,7 @@ if (!(Test-Path "$ImportPath")) {
 $JsonPolicyBody = Get-Content -Path "$ImportPath"
 
 ## Converting JSON to HashTable
-$ConvertedPolicyBody = ($JSON_Data | ConvertFrom-Json -AsHashtable).AdditionalProperties
+$ConvertedPolicyBody = ($JsonPolicyBody | ConvertFrom-Json -AsHashtable).AdditionalProperties
 
 ## Storing the display name of the policy in a variable
 $DisplayName = ($JsonPolicyBody | ConvertFrom-Json).DisplayName


### PR DESCRIPTION
Fixes variable name mismatch in DeviceConfiguration_Import_FromJSON.ps1 line 50.

$JsonPolicyBody is defined on line 47 as Get-Content, but line 50 incorrectly used $JSON_Data (never defined), causing a runtime error.

Fix: Replace $JSON_Data with $JsonPolicyBody on line 50.

Fixes issue #30.