### PR TITLE
Enhance JSON import validation and SettingsCatalog functionality

### DIFF
--- a/DeviceConfiguration/DeviceConfiguration_Import_FromJSON.ps1
+++ b/DeviceConfiguration/DeviceConfiguration_Import_FromJSON.ps1
@@ -19,44 +19,96 @@ https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powers
 #endregion
 
 ####################################################
-$FileName = Read-Host -Prompt "Please specify a path to a JSON file to import data from e.g. C:\IntuneOutput\Policies\policy.json"
 
-Test-Json -Path $FileName
-
-If (Test-Path -Path $FileName -Type Leaf) {
-    $ImportPath = $FileName
-}
-Else {
+# Prompting for the JSON file path and validating it exists and contains valid JSON
+do {
     $ImportPath = Read-Host -Prompt "Please specify a path to a JSON file to import data from e.g. C:\IntuneOutput\Policies\policy.json"
+
+    # Replacing quotes for Test-Path (handles paths pasted with surrounding quotes)
+    $ImportPath = $ImportPath.Replace('"', '').Trim()
+    $PathValid = $false
+
+    if ([string]::IsNullOrWhiteSpace($ImportPath)) {
+        Write-Host "No path was provided. Please try again..." -ForegroundColor Yellow
+    }
+    # Checking the path points to an existing file (not a folder)
+    elseif (!(Test-Path -LiteralPath $ImportPath -PathType Leaf)) {
+        Write-Host "Import path '$ImportPath' doesn't exist or isn't a file. Please try again..." -ForegroundColor Yellow
+    }
+    # Validating the file contains well-formed JSON
+    elseif (!(Get-Content -LiteralPath $ImportPath -Raw | Test-Json -ErrorAction SilentlyContinue)) {
+        Write-Host "File '$ImportPath' doesn't contain valid JSON. Please try again..." -ForegroundColor Yellow
+    }
+    else {
+        $PathValid = $true
+    }
 }
-
-# Replacing quotes for Test-Path
-$ImportPath = $ImportPath.replace('"', '')
-
-if (!(Test-Path "$ImportPath")) {
-
-    Write-Host "Import Path for JSON file doesn't exist..." -ForegroundColor Red
-    Write-Host "Script can't continue..." -ForegroundColor Red
-    break
-
-}
+while (-not $PathValid)
 
 ####################################################
 
 # Importing JSON file
-$JsonPolicyBody = Get-Content -Path "$ImportPath"
+$JsonPolicyBody = Get-Content -LiteralPath $ImportPath -Raw
 
-## Converting JSON to HashTable
-$ConvertedPolicyBody = ($JsonPolicyBody | ConvertFrom-Json -AsHashtable).AdditionalProperties
+## Converting JSON to a hashtable
+$Policy = $JsonPolicyBody | ConvertFrom-Json -AsHashtable
 
-## Storing the display name of the policy in a variable
-$DisplayName = ($JsonPolicyBody | ConvertFrom-Json).DisplayName
+if ($Policy.ContainsKey('AdditionalProperties') -and $Policy.AdditionalProperties.'@odata.type') {
+    $RequestBody = $Policy.AdditionalProperties
+    if (-not $RequestBody.ContainsKey('displayName')) {
+        $RequestBody['displayName'] = $Policy.DisplayName
+    }
+}
+else {
+    $RequestBody = $Policy
+}
 
+if (-not $RequestBody.'@odata.type') {
+    Write-Host "The JSON file is missing the required '@odata.type' property (e.g. '#microsoft.graph.windows10GeneralConfiguration')." -ForegroundColor Red
+    Write-Host "Ensure the file was produced by DeviceConfiguration_Export.ps1. Script can't continue..." -ForegroundColor Red
+    break
+}
+
+## Graph requires every OData type to be prefixed with '#'. Without it the service returns
+## "Invalid OData type specified". Normalise the top-level type and any nested types so the
+## file imports whether or not the '#' was present.
+function Set-ODataTypePrefix {
+    param ($Node)
+
+    if ($Node -is [System.Collections.IDictionary]) {
+        if ($Node.Contains('@odata.type') -and $Node['@odata.type'] -is [string] -and $Node['@odata.type'] -notlike '#*') {
+            $Node['@odata.type'] = '#' + $Node['@odata.type']
+        }
+        foreach ($Value in @($Node.Values)) {
+            Set-ODataTypePrefix -Node $Value
+        }
+    }
+    elseif ($Node -is [System.Collections.IEnumerable] -and $Node -isnot [string]) {
+        foreach ($Item in $Node) {
+            Set-ODataTypePrefix -Node $Item
+        }
+    }
+}
+
+Set-ODataTypePrefix -Node $RequestBody
+
+## Removing read-only properties that the service rejects on create
+foreach ($ReadOnlyProperty in 'id', 'createdDateTime', 'lastModifiedDateTime', 'version', 'supportsScopeTags') {
+    $RequestBody.Remove($ReadOnlyProperty)
+}
+
+$DisplayName = $RequestBody['displayName']
 Write-Host "Device Configuration Policy '$DisplayName' Found..." -ForegroundColor Yellow
 
 ## Displaying the policy settings
-$ConvertedPolicyBody
+$RequestBody
+
 Write-Host "Adding Device Configuration Policy '$DisplayName'" -ForegroundColor Yellow
 
-## Creating the policy in Intune
-New-MgDeviceManagementDeviceConfiguration -DisplayName $DisplayName -AdditionalProperties $JSON_Convert
+## Creating the policy in Intune - using Invoke-MgGraphRequest so the '@odata.type'
+## discriminator is sent and Graph creates the correct concrete type.
+$CreateResult = Invoke-MgGraphRequest -Method POST `
+    -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations" `
+    -Body ($RequestBody | ConvertTo-Json -Depth 20)
+
+Write-Host "Policy created with id" $CreateResult.id -ForegroundColor Green

--- a/SettingsCatalog/SettingsCatalog_Export.ps1
+++ b/SettingsCatalog/SettingsCatalog_Export.ps1
@@ -14,7 +14,7 @@ https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powers
 #>
 Function Get-SettingsCatalogPolicy() {
 
-    <#
+<#
 .SYNOPSIS
 This function is used to get Settings Catalog policies from the Graph API REST interface
 .DESCRIPTION
@@ -35,13 +35,20 @@ NAME: Get-SettingsCatalogPolicy
     param
     (
         [parameter(Mandatory = $false)]
-        [ValidateSet("windows10", "macOS")]
+        [ValidateSet("windows10", "windows10X", "macOS", "iOS", "android", "androidEnterprise", "aosp", "linux", "visionOS", "tvOS")]
         [ValidateNotNullOrEmpty()]
         [string]$Platform
     )
 
     $graphApiVersion = "beta"
 
+    # The 'technologies' value scopes which settings catalog policies are returned. This sample
+    # uses 'mdm', which covers the most common settings catalog policies. Other technologies are
+    # also backed by the configurationPolicies endpoint - for example: endpointPrivilegeManagement
+    # (EPM), enrollment (Autopilot device preparation), windowsOsRecovery, exchangeOnline, and
+    # microsoftSense. If you need to export those, change or remove the "technologies has 'mdm'"
+    # filter below (e.g. "technologies has 'endpointPrivilegeManagement'" or drop the filter
+    # entirely to return every configuration policy regardless of technology).
     if ($Platform) {
         
         $Resource = "deviceManagement/configurationPolicies?`$filter=platforms has '$Platform' and technologies has 'mdm'"
@@ -57,7 +64,22 @@ NAME: Get-SettingsCatalogPolicy
     try {
 
         $uri = "https://graph.microsoft.com/$graphApiVersion/$($Resource)"
-        (Invoke-MgGraphRequest -Uri $uri  -Method Get).Value
+
+        $Response = Invoke-MgGraphRequest -Uri $uri -Method Get
+
+        $AllResponses = $Response.value
+        $ResponseNextLink = $Response."@odata.nextLink"
+
+        # Following @odata.nextLink so all pages are returned, not just the first page
+        while ($null -ne $ResponseNextLink) {
+
+            $Response = Invoke-MgGraphRequest -Uri $ResponseNextLink -Method Get
+            $ResponseNextLink = $Response."@odata.nextLink"
+            $AllResponses += $Response.value
+
+        }
+
+        return $AllResponses
 
     }
 
@@ -165,7 +187,6 @@ NAME: Export-JSONData
 
         $JSON,
         $ExportPath
-
     )
 
     try {
@@ -194,7 +215,9 @@ NAME: Export-JSONData
 
             $JSON_Convert = $JSON1 | ConvertFrom-Json
 
-            $displayName = $JSON_Convert.name
+            # Settings Catalog policies use 'name'; the additional policy types
+            # (resource access profiles, hardware configurations) use 'displayName'
+            $DisplayName = if ($JSON_Convert.name) { $JSON_Convert.name } else { $JSON_Convert.displayName }
 
             # Updating display name to follow file naming conventions - https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247%28v=vs.85%29.aspx
             $DisplayName = $DisplayName -replace '\<|\>|:|"|/|\\|\||\?|\*', "_"
@@ -213,6 +236,110 @@ NAME: Export-JSONData
     catch {
 
         $_.Exception
+
+    }
+
+}
+
+####################################################
+
+Function Get-IntuneResourceCollection() {
+
+    <#
+.SYNOPSIS
+Gets all items from a Graph collection endpoint, following @odata.nextLink paging
+.DESCRIPTION
+Used to retrieve the additional policy types that branched out of the Settings Catalog
+(resource access profiles, hardware configurations) which live on their own endpoints
+.EXAMPLE
+Get-IntuneResourceCollection -Resource "deviceManagement/resourceAccessProfiles"
+.NOTES
+NAME: Get-IntuneResourceCollection
+#>
+
+    [cmdletbinding()]
+
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Resource
+    )
+
+    $graphApiVersion = "beta"
+
+    try {
+
+        $uri = "https://graph.microsoft.com/$graphApiVersion/$Resource"
+        $Response = Invoke-MgGraphRequest -Uri $uri -Method Get
+
+        $AllResponses = $Response.value
+        $ResponseNextLink = $Response."@odata.nextLink"
+
+        while ($null -ne $ResponseNextLink) {
+
+            $Response = Invoke-MgGraphRequest -Uri $ResponseNextLink -Method Get
+            $ResponseNextLink = $Response."@odata.nextLink"
+            $AllResponses += $Response.value
+
+        }
+
+        return $AllResponses
+
+    }
+
+    catch {
+
+        $ex = $_.Exception
+        Write-Host "Request to $uri failed with HTTP Status $($ex.Response.StatusCode): $($ex.Message)" -ForegroundColor Red
+        return $null
+
+    }
+
+}
+
+####################################################
+
+Function Get-IntuneResourceObject() {
+
+    <#
+.SYNOPSIS
+Gets a single object by id from a Graph collection endpoint
+.DESCRIPTION
+Re-fetches an individual policy object so all properties are returned for export
+.EXAMPLE
+Get-IntuneResourceObject -Resource "deviceManagement/hardwareConfigurations" -Id $id
+.NOTES
+NAME: Get-IntuneResourceObject
+#>
+
+    [cmdletbinding()]
+
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Resource,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Id
+    )
+
+    $graphApiVersion = "beta"
+
+    try {
+
+        $uri = "https://graph.microsoft.com/$graphApiVersion/$Resource/$Id"
+        return Invoke-MgGraphRequest -Uri $uri -Method Get
+
+    }
+
+    catch {
+
+        $ex = $_.Exception
+        Write-Host "Request to $uri failed with HTTP Status $($ex.Response.StatusCode): $($ex.Message)" -ForegroundColor Red
+        return $null
 
     }
 
@@ -314,5 +441,51 @@ else {
 
     Write-Host "No Settings Catalog policies found..." -ForegroundColor Red
     Write-Host
+
+}
+
+####################################################
+# Additional policy types that previously appeared under the Settings Catalog but
+# now have their own endpoints. They use a different schema (full object with an
+# '@odata.type' or a configuration file payload) rather than the configuration
+# settings collection, so they are exported as complete objects. The matching
+# import script (SettingsCatalog_Import_FromJSON.ps1) strips read-only properties
+# and posts each object back to the correct endpoint.
+
+$AdditionalResources = @(
+    "deviceManagement/resourceAccessProfiles",
+    "deviceManagement/hardwareConfigurations"
+)
+
+foreach ($Resource in $AdditionalResources) {
+
+    Write-Host
+    Write-Host "Checking $Resource ..." -ForegroundColor Cyan
+
+    $Items = Get-IntuneResourceCollection -Resource $Resource
+
+    if (-not $Items) {
+
+        Write-Host "No items found at $Resource" -ForegroundColor DarkGray
+        continue
+
+    }
+
+    foreach ($Item in $Items) {
+
+        $DisplayName = if ($Item.name) { $Item.name } else { $Item.displayName }
+        Write-Host $DisplayName -ForegroundColor Yellow
+
+        # Re-fetch the individual object so all properties are returned for export
+        $FullItem = Get-IntuneResourceObject -Resource $Resource -Id $Item.id
+
+        if ($FullItem) {
+
+            Export-JSONData -JSON $FullItem -ExportPath "$ExportPath"
+            Write-Host
+
+        }
+
+    }
 
 }

--- a/SettingsCatalog/SettingsCatalog_Import_FromJSON.ps1
+++ b/SettingsCatalog/SettingsCatalog_Import_FromJSON.ps1
@@ -1,0 +1,179 @@
+Import-Module Microsoft.Graph.Beta.DeviceManagement
+
+####################################################
+
+<# region Authentication
+To authenticate, you'll use the Microsoft Graph PowerShell SDK. If you haven't already installed the SDK, see this guide:
+https://learn.microsoft.com/en-us/powershell/microsoftgraph/installation?view=graph-powershell-1.0
+
+The PowerShell SDK supports two types of authentication: delegated access, and app-only access.
+
+For details on using delegated access, see this guide here:
+https://learn.microsoft.com/powershell/microsoftgraph/get-started?view=graph-powershell-1.0
+
+For details on using app-only access for unattended scenarios, see Use app-only authentication with the Microsoft Graph PowerShell SDK:
+https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal
+
+#>
+
+#endregion
+
+####################################################
+
+Function Get-TargetResource() {
+
+<#
+.SYNOPSIS
+Determines which Graph endpoint a policy JSON object should be imported to
+.DESCRIPTION
+This script handles the Settings Catalog policy type as well as the additional
+policy types that branched out of the Settings Catalog (resource access profiles
+and hardware configurations). Each uses a different schema, so the correct target
+endpoint is detected from the shape of the imported object.
+.NOTES
+NAME: Get-TargetResource
+#>
+
+    [cmdletbinding()]
+
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [System.Collections.IDictionary]$Policy
+    )
+
+    # Settings Catalog policies carry a settings collection and the technologies/platforms discriminators
+    if ($Policy.Contains('settings') -or $Policy.Contains('technologies')) {
+        return "deviceManagement/configurationPolicies"
+    }
+
+    # Hardware configurations carry a configuration file payload and format
+    if ($Policy.Contains('hardwareConfigurationFormat') -or $Policy.Contains('configurationFileContent')) {
+        return "deviceManagement/hardwareConfigurations"
+    }
+
+    # Resource access profiles are @odata.type discriminated (Wi-Fi, VPN, certificate, trusted root)
+    $odataType = $Policy['@odata.type']
+    if ($odataType -and $odataType -match 'windows10X|ResourceAccess') {
+        return "deviceManagement/resourceAccessProfiles"
+    }
+
+    return $null
+
+}
+
+####################################################
+
+Function Set-ODataTypePrefix() {
+
+    <#
+.SYNOPSIS
+Ensures every '@odata.type' value is prefixed with '#'
+.DESCRIPTION
+Graph requires every OData type discriminator to be prefixed with '#'. Without it
+the service returns "Invalid OData type specified". This normalises the top-level
+type and any nested types so the file imports whether or not the '#' was present.
+.NOTES
+NAME: Set-ODataTypePrefix
+#>
+
+    param ($Node)
+
+    if ($Node -is [System.Collections.IDictionary]) {
+        if ($Node.Contains('@odata.type') -and $Node['@odata.type'] -is [string] -and $Node['@odata.type'] -notlike '#*') {
+            $Node['@odata.type'] = '#' + $Node['@odata.type']
+        }
+        foreach ($Value in @($Node.Values)) {
+            Set-ODataTypePrefix -Node $Value
+        }
+    }
+    elseif ($Node -is [System.Collections.IEnumerable] -and $Node -isnot [string]) {
+        foreach ($Item in $Node) {
+            Set-ODataTypePrefix -Node $Item
+        }
+    }
+
+}
+
+####################################################
+
+# Prompting for the JSON file path and validating it exists and contains valid JSON
+do {
+    $ImportPath = Read-Host -Prompt "Please specify a path to a JSON file to import data from e.g. C:\IntuneOutput\policy.json"
+
+    # Replacing quotes for Test-Path (handles paths pasted with surrounding quotes)
+    $ImportPath = $ImportPath.Replace('"', '').Trim()
+    $PathValid = $false
+
+    if ([string]::IsNullOrWhiteSpace($ImportPath)) {
+        Write-Host "No path was provided. Please try again..." -ForegroundColor Yellow
+    }
+    # Checking the path points to an existing file (not a folder)
+    elseif (!(Test-Path -LiteralPath $ImportPath -PathType Leaf)) {
+        Write-Host "Import path '$ImportPath' doesn't exist or isn't a file. Please try again..." -ForegroundColor Yellow
+    }
+    # Validating the file contains well-formed JSON
+    elseif (!(Get-Content -LiteralPath $ImportPath -Raw | Test-Json -ErrorAction SilentlyContinue)) {
+        Write-Host "File '$ImportPath' doesn't contain valid JSON. Please try again..." -ForegroundColor Yellow
+    }
+    else {
+        $PathValid = $true
+    }
+}
+while (-not $PathValid)
+
+####################################################
+
+# Importing JSON file and converting to a hashtable so properties can be edited
+$JsonPolicyBody = Get-Content -LiteralPath $ImportPath -Raw
+$RequestBody = $JsonPolicyBody | ConvertFrom-Json -AsHashtable
+
+# Determining which endpoint this policy should be imported to
+$Resource = Get-TargetResource -Policy $RequestBody
+
+if (-not $Resource) {
+    Write-Host "Unable to determine the policy type from the JSON file." -ForegroundColor Red
+    Write-Host "Ensure the file was produced by SettingsCatalog_Export.ps1 and is a Settings Catalog policy, resource access profile, or hardware configuration. Script can't continue..." -ForegroundColor Red
+    break
+}
+
+# Normalising OData type discriminators (resource access profiles require '#')
+Set-ODataTypePrefix -Node $RequestBody
+
+# Removing read-only and navigation properties that the service rejects on create.
+# Nested values (e.g. Settings Catalog settingInstances) are left untouched.
+$ReadOnlyProperties = @(
+    'id', 'createdDateTime', 'creationDateTime', 'lastModifiedDateTime', 'version',
+    'settingCount', 'creationSource', 'priorityMetaData', 'supportsScopeTags', 'isAssigned',
+    'assignments', 'deviceRunStates', 'userRunStates', 'runSummary'
+)
+
+foreach ($Property in $ReadOnlyProperties) {
+    if ($RequestBody.Contains($Property)) {
+        $RequestBody.Remove($Property)
+    }
+}
+
+# Removing OData annotations (e.g. @odata.context) while keeping the @odata.type discriminator
+foreach ($Key in @($RequestBody.Keys)) {
+    if ($Key -like '*@odata*' -and $Key -ne '@odata.type') {
+        $RequestBody.Remove($Key)
+    }
+}
+
+####################################################
+
+$DisplayName = if ($RequestBody['name']) { $RequestBody['name'] } else { $RequestBody['displayName'] }
+Write-Host "Policy '$DisplayName' found, importing to $Resource ..." -ForegroundColor Yellow
+
+# Displaying the policy body that will be sent
+$RequestBody
+
+# Creating the policy in Intune - using Invoke-MgGraphRequest so the '@odata.type'
+# discriminator is sent and Graph creates the correct concrete type.
+$CreateResult = Invoke-MgGraphRequest -Method POST `
+    -Uri "https://graph.microsoft.com/beta/$Resource" `
+    -Body ($RequestBody | ConvertTo-Json -Depth 20)
+
+Write-Host "Policy created with id" $CreateResult.id -ForegroundColor Green

--- a/SettingsCatalog/readme.md
+++ b/SettingsCatalog/readme.md
@@ -15,6 +15,13 @@ Within this section there are the following scripts with the explanation of usag
 ### 1. SettingsCatalog_Export.ps1
 This script gets all the settings catalog policies from the Intune Service that you have authenticated with. The script will then export the policy to .json format in the directory of your choice.
 
+In addition to settings catalog policies, the script also exports two policy types that previously appeared under the Settings Catalog but now live on their own endpoints:
+
++ Resource access profiles (`deviceManagement/resourceAccessProfiles`)
++ Hardware configurations (`deviceManagement/hardwareConfigurations`)
+
+These use a different schema to settings catalog policies, so they are exported as complete objects and re-created by the matching import script.
+
 ```PowerShell
 $ExportPath = Read-Host -Prompt "Please specify a path to export the policy data to e.g. C:\IntuneOutput"
 
@@ -46,9 +53,11 @@ $ExportPath = Read-Host -Prompt "Please specify a path to export the policy data
 ```
 
 #### Get-SettingsCatalogPolicy Function
-This function is used to get all settings catalog policies from the Intune Service.
+This function is used to get all settings catalog policies from the Intune Service. It follows the `@odata.nextLink` paging so every policy is returned, not just the first page, and is scoped to MDM technology policies.
 
-It supports a single parameters as an input to the function to pull data from the service.
+It supports an optional `-Platform` parameter to scope the results to a single platform. Supported values are `windows10`, `windows10X`, `macOS`, `iOS`, `android`, `androidEnterprise`, `aosp`, `linux`, `visionOS`, and `tvOS`.
+
+> **Note on the `technologies` filter:** the function filters on `technologies has 'mdm'`, which covers the most common settings catalog policies. Other technologies are also backed by the same `configurationPolicies` endpoint — for example `endpointPrivilegeManagement` (EPM), `enrollment` (Autopilot device preparation), `windowsOsRecovery`, `exchangeOnline`, and `microsoftSense`. If you need to export those, change or remove the `technologies has 'mdm'` filter in the function (e.g. `technologies has 'endpointPrivilegeManagement'`, or drop the filter entirely to return every configuration policy regardless of technology).
 
 ```PowerShell
 # Returns any Settings Catalog policies configured in Intune
@@ -57,9 +66,23 @@ Get-SettingsCatalogPolicy
 # Returns any Windows 10 Settings Catalog policies configured in Intune
 Get-SettingsCatalogPolicy -Platform windows10
 
-# Returns any MacOS Settings Catalog policies configured in Intune
+# Returns any macOS Settings Catalog policies configured in Intune
 Get-SettingsCatalogPolicy -Platform macOS
 
+# Returns any iOS/iPadOS Settings Catalog policies configured in Intune
+Get-SettingsCatalogPolicy -Platform iOS
+
+```
+
+#### Get-IntuneResourceCollection and Get-IntuneResourceObject Functions
+These functions retrieve the additional policy types that branched out of the Settings Catalog (resource access profiles and hardware configurations). `Get-IntuneResourceCollection` returns all items from a collection endpoint, following `@odata.nextLink` paging, and `Get-IntuneResourceObject` re-fetches a single object by id so all of its properties are returned for export.
+
+```PowerShell
+# Returns all resource access profiles configured in Intune
+Get-IntuneResourceCollection -Resource "deviceManagement/resourceAccessProfiles"
+
+# Returns a single hardware configuration by id
+Get-IntuneResourceObject -Resource "deviceManagement/hardwareConfigurations" -Id $id
 ```
 
 #### Export-JSONData Function
@@ -71,3 +94,22 @@ This function is used to export the policy information. It has two required para
 ```PowerShell
 Export-JSONData -JSON $JSON -ExportPath "$ExportPath"
 ```
+
+### 2. SettingsCatalog_Import_FromJSON.ps1
+This script imports a policy from a .json file (such as one produced by SettingsCatalog_Export.ps1) back into the Intune Service. It handles settings catalog policies as well as the additional policy types that branched out of the Settings Catalog (resource access profiles and hardware configurations).
+
+The script prompts for the path to a single .json file, validates that the file exists and contains valid JSON, determines which endpoint the policy should be created on, removes read-only properties, and creates the policy in Intune.
+
+```PowerShell
+$ImportPath = Read-Host -Prompt "Please specify a path to a JSON file to import data from e.g. C:\IntuneOutput\policy.json"
+```
+
+#### Get-TargetResource Function
+This function determines which Graph endpoint a policy JSON object should be imported to, based on the shape of the object:
+
++ Settings catalog policies (a `settings` collection / `technologies` value) are created on `deviceManagement/configurationPolicies`
++ Hardware configurations (a `configurationFileContent` / `hardwareConfigurationFormat` value) are created on `deviceManagement/hardwareConfigurations`
++ Resource access profiles (an `@odata.type` discriminator) are created on `deviceManagement/resourceAccessProfiles`
+
+#### Set-ODataTypePrefix Function
+This function ensures every `@odata.type` value is prefixed with `#`, which Graph requires for the OData type discriminator. It normalises the top-level type and any nested types so the file imports whether or not the `#` was present.


### PR DESCRIPTION
This pull request significantly expands and improves the Intune Settings Catalog export and import scripts to support additional policy types (resource access profiles and hardware configurations), improves paging and platform support, and enhances documentation. The main changes introduce new helper functions for exporting/importing these additional policy types, ensure all items are exported even with paged results, and add validation and normalization for imported JSON files.

**Support for additional policy types:**
- The export (`SettingsCatalog_Export.ps1`) and import (`SettingsCatalog_Import_FromJSON.ps1`) scripts now handle resource access profiles and hardware configurations, which previously appeared under the Settings Catalog but now have their own endpoints. These are exported as full objects and imported back to the correct endpoint, with schema detection and normalization. [[1]](diffhunk://#diff-ba3cff82ada0ca272dbfc3a4e8414f8661d0d91022a373da4cc6f109f1940a95R1-R179) [[2]](diffhunk://#diff-d0d1e028c7934fc14d373ce27a0247c8093ec6f1dcd527158f4fdbb4e29043a3R246-R349) [[3]](diffhunk://#diff-d0d1e028c7934fc14d373ce27a0247c8093ec6f1dcd527158f4fdbb4e29043a3R446-R491) [[4]](diffhunk://#diff-3e1f6056fdfd81989dde3afa8725c4874c72fd2fb3e69725e42d16d76be625e1R18-R24)

**Export script improvements:**
- Added `Get-IntuneResourceCollection` and `Get-IntuneResourceObject` helper functions to fetch all items from a collection endpoint (following `@odata.nextLink` for paging) and to re-fetch individual objects for complete export. [[1]](diffhunk://#diff-d0d1e028c7934fc14d373ce27a0247c8093ec6f1dcd527158f4fdbb4e29043a3R246-R349) [[2]](diffhunk://#diff-3e1f6056fdfd81989dde3afa8725c4874c72fd2fb3e69725e42d16d76be625e1L60-R85)
- The `Get-SettingsCatalogPolicy` function now supports many more platforms (windows10X, iOS, android, etc.), and follows `@odata.nextLink` so all policies are exported, not just the first page. [[1]](diffhunk://#diff-d0d1e028c7934fc14d373ce27a0247c8093ec6f1dcd527158f4fdbb4e29043a3L38-R51) [[2]](diffhunk://#diff-d0d1e028c7934fc14d373ce27a0247c8093ec6f1dcd527158f4fdbb4e29043a3L60-R82) [[3]](diffhunk://#diff-3e1f6056fdfd81989dde3afa8725c4874c72fd2fb3e69725e42d16d76be625e1L49-R60)
- Improved display name handling for file naming to support both `name` and `displayName` properties, accommodating schema differences.

**Import script improvements:**
- Added a new `SettingsCatalog_Import_FromJSON.ps1` script that determines the correct Graph endpoint for each imported policy based on its schema, normalizes OData type discriminators, and removes read-only properties and OData annotations before import.
- Improved validation and error handling for the import file path and JSON structure. [[1]](diffhunk://#diff-284804ee80a6d5eb1edccf54688aabbe16e395f514884f6edf3a7a5a36dbd5eaL22-R114) [[2]](diffhunk://#diff-ba3cff82ada0ca272dbfc3a4e8414f8661d0d91022a373da4cc6f109f1940a95R1-R179)

**Documentation updates:**
- Updated `readme.md` to document support for the new policy types, expanded platform support, paging, and the new helper functions. [[1]](diffhunk://#diff-3e1f6056fdfd81989dde3afa8725c4874c72fd2fb3e69725e42d16d76be625e1R18-R24) [[2]](diffhunk://#diff-3e1f6056fdfd81989dde3afa8725c4874c72fd2fb3e69725e42d16d76be625e1L49-R60) [[3]](diffhunk://#diff-3e1f6056fdfd81989dde3afa8725c4874c72fd2fb3e69725e42d16d76be625e1L60-R85)

These changes make the export/import process more robust, future-proof, and compatible with the evolving Intune schema.

---

**Support for additional policy types:**
- Added export and import support for resource access profiles and hardware configurations, including endpoint detection and schema normalization. (`SettingsCatalog_Export.ps1`, `SettingsCatalog_Import_FromJSON.ps1`, `readme.md`) [[1]](diffhunk://#diff-ba3cff82ada0ca272dbfc3a4e8414f8661d0d91022a373da4cc6f109f1940a95R1-R179) [[2]](diffhunk://#diff-d0d1e028c7934fc14d373ce27a0247c8093ec6f1dcd527158f4fdbb4e29043a3R246-R349) [[3]](diffhunk://#diff-d0d1e028c7934fc14d373ce27a0247c8093ec6f1dcd527158f4fdbb4e29043a3R446-R491) [[4]](diffhunk://#diff-3e1f6056fdfd81989dde3afa8725c4874c72fd2fb3e69725e42d16d76be625e1R18-R24)

**Export script improvements:**
- Implemented `Get-IntuneResourceCollection` and `Get-IntuneResourceObject` to handle paged results and fetch complete objects for export. (`SettingsCatalog_Export.ps1`, `readme.md`) [[1]](diffhunk://#diff-d0d1e028c7934fc14d373ce27a0247c8093ec6f1dcd527158f4fdbb4e29043a3R246-R349) [[2]](diffhunk://#diff-3e1f6056fdfd81989dde3afa8725c4874c72fd2fb3e69725e42d16d76be625e1L60-R85)
- Enhanced `Get-SettingsCatalogPolicy` to support more platforms and follow `@odata.nextLink` for complete exports. (`SettingsCatalog_Export.ps1`, `readme.md`) [[1]](diffhunk://#diff-d0d1e028c7934fc14d373ce27a0247c8093ec6f1dcd527158f4fdbb4e29043a3L38-R51) [[2]](diffhunk://#diff-d0d1e028c7934fc14d373ce27a0247c8093ec6f1dcd527158f4fdbb4e29043a3L60-R82) [[3]](diffhunk://#diff-3e1f6056fdfd81989dde3afa8725c4874c72fd2fb3e69725e42d16d76be625e1L49-R60)
- Improved file naming to handle both `name` and `displayName` properties. (`SettingsCatalog_Export.ps1`)

**Import script improvements:**
- Added schema detection, OData type normalization, and read-only property removal to the import process. (`SettingsCatalog_Import_FromJSON.ps1`)
- Improved validation for import file path and JSON structure. (`DeviceConfiguration_Import_FromJSON.ps1`, `SettingsCatalog_Import_FromJSON.ps1`) [[1]](diffhunk://#diff-284804ee80a6d5eb1edccf54688aabbe16e395f514884f6edf3a7a5a36dbd5eaL22-R114) [[2]](diffhunk://#diff-ba3cff82ada0ca272dbfc3a4e8414f8661d0d91022a373da4cc6f109f1940a95R1-R179)

**Documentation updates:**
- Updated documentation to reflect new features, helper functions, and expanded platform support. (`readme.md`) [[1]](diffhunk://#diff-3e1f6056fdfd81989dde3afa8725c4874c72fd2fb3e69725e42d16d76be625e1R18-R24) [[2]](diffhunk://#diff-3e1f6056fdfd81989dde3afa8725c4874c72fd2fb3e69725e42d16d76be625e1L49-R60) [[3]](diffhunk://#diff-3e1f6056fdfd81989dde3afa8725c4874c72fd2fb3e69725e42d16d76be625e1L60-R85)