### PR TITLE
Add PowerShell script for updating MSIX/AppX applications in Intune + Added icon sample to Win32

### DIFF
--- a/LOB_Application/MSIX_Application_Add.ps1
+++ b/LOB_Application/MSIX_Application_Add.ps1
@@ -1,0 +1,787 @@
+#requires -module Microsoft.Graph.Devices.CorporateManagement
+#requires -module Microsoft.Graph.Authentication
+
+<# region Authentication
+To authenticate, you'll use the Microsoft Graph PowerShell SDK. If you haven't already installed the SDK, see this guide:
+https://learn.microsoft.com/en-us/powershell/microsoftgraph/installation?view=graph-powershell-1.0
+The PowerShell SDK supports two types of authentication: delegated access, and app-only access.
+For details on using delegated access, see this guide here:
+https://learn.microsoft.com/powershell/microsoftgraph/get-started?view=graph-powershell-1.0
+For details on using app-only access for unattended scenarios, see Use app-only authentication with the Microsoft Graph PowerShell SDK:
+https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal
+#>
+
+<#
+.SYNOPSIS
+Uploads an MSIX/AppX line-of-business app (windowsUniversalAppX) to Intune.
+
+.DESCRIPTION
+This function uploads an MSIX/AppX line-of-business app to Intune.
+
+Unlike a Win32 (.intunewin) app, an .msix/.appx package is NOT pre-encrypted and does NOT contain a
+detection.xml. Instead, the script:
+  1. Extracts the package manifest (AppxManifest.xml, or AppxBundleManifest.xml for *.msixbundle / *.appxbundle).
+  2. Parses the package Identity (Name, Publisher, Version, ProcessorArchitecture, ResourceId).
+  3. Computes the Identity Publisher Hash from the Identity Publisher string (the same hash that forms the
+     last segment of a package family name).
+  4. Encrypts the package locally (AES + HMAC-SHA256) and uploads the encrypted copy to Azure Storage.
+  5. Commits the encrypted file and publishes the windowsUniversalAppX app.
+
+.PARAMETER SourceFile
+The path to the .msix, .msixbundle, .appx, or .appxbundle file.
+
+.PARAMETER displayName
+The display name of the app. If not specified, the script uses the package DisplayName (or Identity Name) from the manifest.
+
+.PARAMETER publisher
+The publisher of the app. If not specified, the script uses the package PublisherDisplayName (or Identity Publisher) from the manifest.
+
+.PARAMETER description
+The description of the app. If not specified, the script uses the display name.
+
+.PARAMETER minimumSupportedOperatingSystem
+The minimum supported operating system for the app, as a windowsMinimumOperatingSystem hashtable.
+Valid keys for windowsUniversalAppX are 'v8_0', 'v8_1', and 'v10_0'. Defaults to @{ v10_0 = $true }.
+
+.PARAMETER IconFile
+The path to an image file (.png, .jpg, .jpeg, or .gif) to use as the app icon. The image is converted to a mimeContent object and uploaded as the app's largeIcon. Optional.
+
+.EXAMPLE
+# Uploads an .msix app to Intune, letting the script parse the display name, publisher, and identity from the package.
+Invoke-MSIXAppUpload -SourceFile "C:\IntuneApps\Contoso\Contoso.DemoApp_1.0.0.0_x64.msix"
+
+.EXAMPLE
+# Uploads an .msix app with an explicit display name, publisher, description, and app icon.
+Invoke-MSIXAppUpload -SourceFile "C:\IntuneApps\Contoso\Contoso.DemoApp_1.0.0.0_x64.msix" -displayName "Contoso Demo App" -publisher "Contoso" -description "Contoso Demo App (MSIX)" -IconFile "C:\IntuneApps\Contoso\icon.png"
+
+.EXAMPLE
+# Uploads an .msixbundle app and overrides the minimum supported operating system.
+Invoke-MSIXAppUpload -SourceFile "C:\IntuneApps\Contoso\Contoso.DemoApp_1.0.0.0_x64.msixbundle" -displayName "Contoso Demo App" -minimumSupportedOperatingSystem @{ v10_0 = $true }
+#>
+function Invoke-MSIXAppUpload {
+    [cmdletbinding()]
+    param
+    (
+        [parameter(Mandatory = $true, Position = 1)]
+        [ValidateNotNullOrEmpty()]
+        [string]$SourceFile,
+
+        [parameter(Mandatory = $false, Position = 2)]
+        [string]$displayName,
+
+        [parameter(Mandatory = $false, Position = 3)]
+        [string]$publisher,
+
+        [parameter(Mandatory = $false, Position = 4)]
+        [string]$description,
+
+        [parameter(Mandatory = $false, Position = 5)]
+        [hashtable]$minimumSupportedOperatingSystem,
+
+        [parameter(Mandatory = $false, Position = 6)]
+        [string]$IconFile
+    )
+
+    # Temp encrypted copy of the package (created during the encryption step, removed in the finally block)
+    $tempFile = $null
+
+    try {
+        # Check if the source file exists and has a supported extension
+        Write-Host "Testing if SourceFile '$SourceFile' Path is valid..." -ForegroundColor Yellow
+        Test-SourceFile "$SourceFile"
+
+        $Ext = [System.IO.Path]::GetExtension("$SourceFile").ToLower()
+        if ($Ext -notin '.msix', '.msixbundle', '.appx', '.appxbundle') {
+            throw "Unsupported file type '$Ext'. Supported types are .msix, .msixbundle, .appx, and .appxbundle."
+        }
+
+        Write-Host "Parsing the package manifest..." -ForegroundColor Yellow
+
+        # Extract and parse the package manifest to get the identity metadata that Intune requires.
+        # This is the key difference vs. Win32: there is no detection.xml, so the metadata comes from
+        # AppxManifest.xml (or AppxBundleManifest.xml for bundles).
+        $AppInfo = Get-MSIXAppInformation -SourceFile "$SourceFile"
+
+        Write-Host "Package identity parsed from manifest:" -ForegroundColor Gray
+        Write-Host "  Identity Name        : $($AppInfo.IdentityName)" -ForegroundColor Gray
+        Write-Host "  Identity Version     : $($AppInfo.IdentityVersion)" -ForegroundColor Gray
+        Write-Host "  Identity Publisher   : $($AppInfo.IdentityPublisher)" -ForegroundColor Gray
+        Write-Host "  Publisher Hash       : $($AppInfo.IdentityPublisherHash)" -ForegroundColor Gray
+        Write-Host "  Architecture(s)      : $($AppInfo.ApplicableArchitectures)" -ForegroundColor Gray
+        Write-Host "  Is Bundle            : $($AppInfo.IsBundle)" -ForegroundColor Gray
+
+        # Resolve the values that can be overridden by the caller, otherwise fall back to the manifest.
+        if (!$displayName) { $displayName = if ($AppInfo.DisplayName) { $AppInfo.DisplayName } else { $AppInfo.IdentityName } }
+        if (!$publisher) { $publisher = if ($AppInfo.PublisherDisplayName) { $AppInfo.PublisherDisplayName } else { $AppInfo.IdentityPublisher } }
+        if (!$description) { $description = $displayName }
+        if (!$minimumSupportedOperatingSystem) { $minimumSupportedOperatingSystem = @{ "v10_0" = $true } }
+
+        $FileName = [System.IO.Path]::GetFileName("$SourceFile")
+
+        # Build the windowsUniversalAppX app body
+        Write-Host "Creating JSON data to pass to the service..." -ForegroundColor Yellow
+        $mobileAppBody = New-MSIXAppBody `
+            -displayName "$displayName" `
+            -publisher "$publisher" `
+            -description "$description" `
+            -fileName "$FileName" `
+            -identityName $AppInfo.IdentityName `
+            -identityPublisherHash $AppInfo.IdentityPublisherHash `
+            -identityResourceIdentifier $AppInfo.IdentityResourceIdentifier `
+            -identityVersion $AppInfo.IdentityVersion `
+            -isBundle $AppInfo.IsBundle `
+            -applicableArchitectures $AppInfo.ApplicableArchitectures `
+            -applicableDeviceTypes "desktop" `
+            -minimumSupportedOperatingSystem $minimumSupportedOperatingSystem
+
+        # Add the app icon (largeIcon) if an icon file was provided
+        if ($IconFile) {
+            Write-Host "Adding app icon from '$IconFile'..." -ForegroundColor Yellow
+            $mobileAppBody.Add("largeIcon", (New-IntuneAppIcon -IconFile $IconFile))
+        }
+
+        # Create the application in Intune and get the application ID
+        Write-Host "Creating application in Intune..." -ForegroundColor Yellow
+        $MobileApp = New-MgDeviceAppManagementMobileApp -BodyParameter ($mobileAppBody | ConvertTo-Json)
+        $mobileAppId = $MobileApp.id
+
+        # Create a new content version for the application
+        Write-Host "Creating Content Version in the service for the application..." -ForegroundColor Yellow
+        $ContentVersion = New-MgDeviceAppManagementMobileAppAsWindowsUniversalAppXContentVersion -MobileAppId $mobileAppId -BodyParameter @{}
+        $ContentVersionId = $ContentVersion.id
+
+        # Encrypt a copy of the package. Unlike a .intunewin file (which is already encrypted), the .msix is
+        # a raw file, so the script generates the encryption keys and computes the file digest itself.
+        Write-Host "Encrypting a copy of the package '$SourceFile'..." -ForegroundColor Yellow
+        $tempFile = [System.IO.Path]::Combine([System.IO.Path]::GetDirectoryName("$SourceFile"), [System.IO.Path]::GetFileNameWithoutExtension("$SourceFile") + "_" + [guid]::NewGuid().ToString() + "_temp.bin")
+        $fileEncryptionInfo = EncryptFile "$SourceFile" "$tempFile"
+
+        [int64]$Size = (Get-Item "$SourceFile").Length
+        $EncrySize = (Get-Item "$tempFile").Length
+
+        # Create a new file entry in Azure for the upload. Unlike Win32/macOS content files, a
+        # windowsUniversalAppX content file requires a (non-null) manifest. For MSIX/AppX the service only
+        # requires the base64-encoded file name here (the rich identity metadata is supplied on the app body).
+        $encodedManifest = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($FileName))
+        $fileBody = GetAppFileBody "$FileName" $Size $EncrySize $encodedManifest
+        Write-Host "Creating a new file entry in Azure for the upload..." -ForegroundColor Yellow
+        $ContentVersionFile = New-MgDeviceAppManagementMobileAppAsWindowsUniversalAppXContentVersionFile -MobileAppId $mobileAppId -MobileAppContentId $ContentVersionId -BodyParameter ($fileBody | ConvertTo-Json)
+        $ContentVersionFileId = $ContentVersionFile.id
+
+        # Get the file URI for the upload
+        $fileUri = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$mobileAppId/microsoft.graph.windowsUniversalAppX/contentVersions/$ContentVersionId/files/$ContentVersionFileId"
+
+        # Wait for the Azure Storage SAS URI to be created
+        Write-Host "Waiting for the file entry SAS URI to be created..." -ForegroundColor Yellow
+        $file = WaitForFileProcessing $fileUri "AzureStorageUriRequest"
+
+        # Upload the encrypted file to Azure Storage
+        Write-Host "Uploading the file to Azure Storage..." -ForegroundColor Yellow
+        [UInt64]$BlockSizeMB = 4
+        UploadFileToAzureStorage $file.azureStorageUri "$tempFile" $BlockSizeMB
+
+        # Commit the file to the service using the encryption information
+        Write-Host "Committing the file to the service..." -ForegroundColor Yellow
+        Start-Sleep -Seconds 5
+        Invoke-MgCommitDeviceAppManagementMobileAppMicrosoftGraphWindowsUniversalAppXContentVersionFile -MobileAppId $mobileAppId -MobileAppContentId $ContentVersionId -MobileAppContentFileId $ContentVersionFileId -BodyParameter ($fileEncryptionInfo | ConvertTo-Json)
+
+        # Wait for the file to be processed
+        Write-Host "Waiting for the file to be processed..." -ForegroundColor Yellow
+        $file = WaitForFileProcessing $fileUri "CommitFile"
+
+        # Update the application with the committed content version
+        $params = @{
+            "@odata.type"           = "#microsoft.graph.windowsUniversalAppX"
+            committedContentVersion = "$ContentVersionId"
+        }
+        Write-Host "Updating the application with the new content version..." -ForegroundColor Yellow
+        Update-MgDeviceAppManagementMobileApp -MobileAppId $mobileAppId -BodyParameter ($params | ConvertTo-Json)
+
+        # Return the application details
+        Write-Host "Application created successfully." -ForegroundColor Green
+        Write-Host "Application Details:"
+        Get-MgDeviceAppManagementMobileApp -MobileAppId $mobileAppId | Format-List
+    }
+    catch {
+        Write-Host -ForegroundColor Red "Aborting with exception: $($_.Exception.ToString())"
+
+        # In the event that the creation of the app record in Intune succeeded, but processing/file upload failed, you can remove the comment block around the code below to delete the app record.
+        # This will allow you to re-run the script without having to manually delete the incomplete app record.
+        # Note: This will only work if the app record was successfully created in Intune.
+
+        <#
+        if ($mobileAppId) {
+            Write-Host "Removing the incomplete application record from Intune..." -ForegroundColor Yellow
+            Remove-MgDeviceAppManagementMobileApp -MobileAppId $mobileAppId
+        }
+        #>
+        break
+    }
+    finally {
+        # Clean up the temporary encrypted copy of the package
+        if ($tempFile -and (Test-Path "$tempFile")) {
+            Remove-Item -Path "$tempFile" -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+Extracts and parses the manifest of an MSIX/AppX package.
+
+.DESCRIPTION
+This function opens an .msix/.appx (or .msixbundle/.appxbundle) package, extracts the package manifest,
+and returns a hashtable of the identity metadata required to create a windowsUniversalAppX app in Intune.
+
+.PARAMETER SourceFile
+The path to the .msix, .msixbundle, .appx, or .appxbundle file.
+
+.EXAMPLE
+$AppInfo = Get-MSIXAppInformation -SourceFile "C:\IntuneApps\Contoso\Contoso.DemoApp_1.0.0.0_x64.msix"
+#>
+function Get-MSIXAppInformation() {
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$SourceFile
+    )
+
+    $Ext = [System.IO.Path]::GetExtension("$SourceFile").ToLower()
+    $IsBundle = ($Ext -eq '.msixbundle' -or $Ext -eq '.appxbundle')
+    $ManifestName = if ($IsBundle) { 'AppxBundleManifest.xml' } else { 'AppxManifest.xml' }
+
+    # Read the manifest XML out of the package (an .msix/.appx is a ZIP archive)
+    Add-Type -Assembly System.IO.Compression.FileSystem
+    $zip = [IO.Compression.ZipFile]::OpenRead("$SourceFile")
+    try {
+        $entry = $zip.Entries | Where-Object { $_.FullName -ieq $ManifestName -or $_.Name -ieq $ManifestName } | Select-Object -First 1
+        if (!$entry) {
+            throw "Could not find '$ManifestName' in '$SourceFile'. The file may not be a valid MSIX/AppX package."
+        }
+        $reader = New-Object System.IO.StreamReader($entry.Open())
+        $ManifestXml = $reader.ReadToEnd()
+        $reader.Close()
+    }
+    finally {
+        $zip.Dispose()
+    }
+
+    [xml]$Manifest = $ManifestXml
+
+    # The Identity element lives under <Bundle> for bundles and <Package> for single packages
+    if ($IsBundle) {
+        $Identity = $Manifest.Bundle.Identity
+        # A bundle's identity has no ProcessorArchitecture; collect the distinct architectures of the
+        # contained packages instead.
+        $Architectures = @($Manifest.Bundle.Packages.Package |
+                Where-Object { $_.Architecture } |
+                ForEach-Object { ConvertTo-WindowsArchitecture $_.Architecture } |
+                Select-Object -Unique)
+        if (!$Architectures -or $Architectures.Count -eq 0) { $Architectures = @("neutral") }
+        $ApplicableArchitectures = ($Architectures -join ",")
+        $DisplayName = $null
+        $PublisherDisplayName = $null
+    }
+    else {
+        $Identity = $Manifest.Package.Identity
+        $ApplicableArchitectures = ConvertTo-WindowsArchitecture $Identity.ProcessorArchitecture
+        $DisplayName = $Manifest.Package.Properties.DisplayName
+        $PublisherDisplayName = $Manifest.Package.Properties.PublisherDisplayName
+    }
+
+    # The identity Publisher (e.g. "CN=Contoso") is hashed to produce the Identity Publisher Hash that
+    # Intune stores (the same hash used as the last segment of a package family name).
+    $PublisherHash = Get-MSIXPublisherHash -Publisher $Identity.Publisher
+
+    return @{
+        IdentityName               = $Identity.Name
+        IdentityVersion            = $Identity.Version
+        IdentityPublisher          = $Identity.Publisher
+        IdentityPublisherHash      = $PublisherHash
+        IdentityResourceIdentifier = if ($Identity.ResourceId) { $Identity.ResourceId } else { "" }
+        ApplicableArchitectures    = $ApplicableArchitectures
+        IsBundle                   = $IsBundle
+        DisplayName                = $DisplayName
+        PublisherDisplayName       = $PublisherDisplayName
+    }
+}
+
+<#
+.SYNOPSIS
+Computes the Identity Publisher Hash for an MSIX/AppX publisher string.
+
+.DESCRIPTION
+This function computes the publisher hash that Intune stores in the windowsUniversalAppX
+identityPublisherHash property. This is the same hash that forms the last segment of a package family
+name (for example, the "8wekyb3d8bbwe" in a Microsoft package family name).
+
+The algorithm is:
+  1. UTF-16LE encode the publisher string.
+  2. Compute its SHA-256 hash.
+  3. Take the first 8 bytes (64 bits) and pad to 65 bits.
+  4. Encode each 5-bit group using the alphabet "0123456789abcdefghjkmnpqrstvwxyz".
+
+.PARAMETER Publisher
+The Identity Publisher string from the manifest (for example, "CN=Contoso").
+
+.EXAMPLE
+Get-MSIXPublisherHash -Publisher "CN=Contoso"
+#>
+function Get-MSIXPublisherHash() {
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Publisher
+    )
+
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $hashBytes = $sha256.ComputeHash([System.Text.Encoding]::Unicode.GetBytes($Publisher))
+    }
+    finally {
+        $sha256.Dispose()
+    }
+
+    # Build a binary string from the first 8 bytes (64 bits), then pad to 65 bits so it splits into 13 groups of 5 bits.
+    $binary = -join ($hashBytes[0..7] | ForEach-Object { [System.Convert]::ToString($_, 2).PadLeft(8, '0') })
+    $binary = $binary.PadRight(65, '0')
+
+    $encoding = '0123456789abcdefghjkmnpqrstvwxyz'
+    $result = New-Object System.Text.StringBuilder
+    for ($i = 0; $i -lt 65; $i += 5) {
+        $index = [System.Convert]::ToInt32($binary.Substring($i, 5), 2)
+        [void]$result.Append($encoding[$index])
+    }
+
+    return $result.ToString()
+}
+
+<#
+.SYNOPSIS
+Maps an MSIX/AppX processor architecture to a Graph windowsArchitecture value.
+
+.DESCRIPTION
+This function maps the ProcessorArchitecture/Architecture value from a package manifest to the
+corresponding value used by the windowsUniversalAppX applicableArchitectures property.
+
+.PARAMETER Architecture
+The processor architecture from the manifest (for example, "x64", "x86", "arm", "arm64", or "neutral").
+
+.EXAMPLE
+ConvertTo-WindowsArchitecture "x64"
+#>
+function ConvertTo-WindowsArchitecture() {
+    param
+    (
+        [parameter(Mandatory = $false)]
+        [string]$Architecture
+    )
+
+    switch ("$Architecture".ToLower()) {
+        "x64" { "x64" }
+        "x86" { "x86" }
+        "arm" { "arm" }
+        "arm64" { "arm64" }
+        "neutral" { "neutral" }
+        default { "neutral" }
+    }
+}
+
+<#
+.SYNOPSIS
+Constructs the JSON body for a windowsUniversalAppX (MSIX/AppX) app.
+
+.DESCRIPTION
+This function builds the hashtable body used to create a windowsUniversalAppX app in Intune.
+
+.EXAMPLE
+$body = New-MSIXAppBody -displayName "Contoso Demo App" -publisher "Contoso" -description "Contoso Demo App" -fileName "Contoso.DemoApp_1.0.0.0_x64.msix" -identityName "Contoso.DemoApp" -identityPublisherHash "ab82cd0xyz" -identityResourceIdentifier "" -identityVersion "1.0.0.0" -isBundle $false -applicableArchitectures "x64" -applicableDeviceTypes "desktop" -minimumSupportedOperatingSystem @{ v10_0 = $true }
+#>
+function New-MSIXAppBody() {
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [string]$displayName,
+
+        [parameter(Mandatory = $true)]
+        [string]$publisher,
+
+        [parameter(Mandatory = $true)]
+        [string]$description,
+
+        [parameter(Mandatory = $true)]
+        [string]$fileName,
+
+        [parameter(Mandatory = $true)]
+        [string]$identityName,
+
+        [parameter(Mandatory = $true)]
+        [string]$identityPublisherHash,
+
+        [parameter(Mandatory = $false)]
+        [string]$identityResourceIdentifier,
+
+        [parameter(Mandatory = $true)]
+        [string]$identityVersion,
+
+        [parameter(Mandatory = $true)]
+        [bool]$isBundle,
+
+        [parameter(Mandatory = $true)]
+        [string]$applicableArchitectures,
+
+        [parameter(Mandatory = $false)]
+        [string]$applicableDeviceTypes = "desktop",
+
+        [parameter(Mandatory = $true)]
+        [hashtable]$minimumSupportedOperatingSystem
+    )
+
+    $body = @{ "@odata.type" = "#microsoft.graph.windowsUniversalAppX" }
+    $body.displayName = $displayName
+    $body.publisher = $publisher
+    $body.description = $description
+    $body.fileName = $fileName
+    $body.developer = ""
+    $body.notes = ""
+    $body.owner = ""
+    $body.isFeatured = $false
+    $body.informationUrl = $null
+    $body.privacyInformationUrl = $null
+    $body.applicableArchitectures = $applicableArchitectures
+    $body.applicableDeviceTypes = $applicableDeviceTypes
+    $body.identityName = $identityName
+    $body.identityPublisherHash = $identityPublisherHash
+    $body.identityResourceIdentifier = $identityResourceIdentifier
+    $body.identityVersion = $identityVersion
+    $body.isBundle = $isBundle
+    $body.minimumSupportedOperatingSystem = $minimumSupportedOperatingSystem
+
+    return $body
+}
+
+<#
+.SYNOPSIS
+Converts an image file to a mimeContent object for use as an app icon.
+
+.DESCRIPTION
+This function reads an image file from disk, base64-encodes its content, and returns a mimeContent hashtable that can be assigned to a mobileApp's largeIcon property. Supported image types are .png, .jpg, .jpeg, and .gif.
+
+.PARAMETER IconFile
+The path to the image file to use as the app icon.
+
+.EXAMPLE
+# Creates a mimeContent icon object from a .png file.
+New-IntuneAppIcon -IconFile "C:\IntuneApps\Contoso\icon.png"
+#>
+function New-IntuneAppIcon() {
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$IconFile
+    )
+
+    # Check the icon file exists
+    if (!(Test-Path "$IconFile")) {
+        Write-Host "Icon file '$IconFile' doesn't exist..." -ForegroundColor Red
+        throw "Icon file not found: $IconFile"
+    }
+
+    # Determine the MIME type from the file extension
+    $Extension = [System.IO.Path]::GetExtension("$IconFile").ToLower()
+    switch ($Extension) {
+        ".png" { $MimeType = "image/png" }
+        ".jpg" { $MimeType = "image/jpeg" }
+        ".jpeg" { $MimeType = "image/jpeg" }
+        ".gif" { $MimeType = "image/gif" }
+        default {
+            Write-Host "Unsupported icon file type '$Extension'. Supported types are .png, .jpg, .jpeg, and .gif." -ForegroundColor Red
+            throw "Unsupported icon file type: $Extension"
+        }
+    }
+
+    # Read the image file and base64-encode its content
+    $IconContent = [System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$IconFile"))
+
+    # Construct and return the mimeContent object (used as the app's largeIcon)
+    $Icon = @{
+        "@odata.type" = "#microsoft.graph.mimeContent"
+        "type"        = $MimeType
+        "value"       = $IconContent
+    }
+
+    return $Icon
+}
+
+####################################################
+# Function to test if the source file exists
+Function Test-SourceFile() {
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        $SourceFile
+    )
+    try {
+        if (!(Test-Path "$SourceFile")) {
+            Write-Host
+            Write-Host "Source File '$SourceFile' doesn't exist..." -ForegroundColor Red
+            throw
+        }
+    }
+    catch {
+        Write-Host -ForegroundColor Red $_.Exception.Message
+        Write-Host
+        break
+    }
+}
+
+####################################################
+# Function to generate the AES encryption key
+function GenerateKey {
+    try {
+        $aes = [System.Security.Cryptography.Aes]::Create()
+        $aesProvider = New-Object System.Security.Cryptography.AesCryptoServiceProvider
+        $aesProvider.GenerateKey()
+        $aesProvider.Key
+    }
+    finally {
+        if ($null -ne $aesProvider) { $aesProvider.Dispose() }
+        if ($null -ne $aes) { $aes.Dispose() }
+    }
+}
+
+####################################################
+# Function to generate the AES initialization vector
+function GenerateIV {
+    try {
+        $aes = [System.Security.Cryptography.Aes]::Create()
+        $aes.IV
+    }
+    finally {
+        if ($null -ne $aes) { $aes.Dispose() }
+    }
+}
+
+####################################################
+# Function to create the encrypted target file, compute the HMAC value, and return the HMAC value
+function EncryptFileWithIV($sourceFile, $targetFile, $encryptionKey, $hmacKey, $initializationVector) {
+    $bufferBlockSize = 1024 * 4
+    $computedMac = $null
+
+    try {
+        $aes = [System.Security.Cryptography.Aes]::Create()
+        $hmacSha256 = New-Object System.Security.Cryptography.HMACSHA256
+        $hmacSha256.Key = $hmacKey
+        $hmacLength = $hmacSha256.HashSize / 8
+
+        $buffer = New-Object byte[] $bufferBlockSize
+        $bytesRead = 0
+
+        $targetStream = [System.IO.File]::Open($targetFile, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::Read)
+        $targetStream.Write($buffer, 0, $hmacLength + $initializationVector.Length)
+
+        try {
+            $encryptor = $aes.CreateEncryptor($encryptionKey, $initializationVector)
+            $sourceStream = [System.IO.File]::Open($sourceFile, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::Read)
+            $cryptoStream = New-Object System.Security.Cryptography.CryptoStream -ArgumentList @($targetStream, $encryptor, [System.Security.Cryptography.CryptoStreamMode]::Write)
+
+            $targetStream = $null
+            while (($bytesRead = $sourceStream.Read($buffer, 0, $bufferBlockSize)) -gt 0) {
+                $cryptoStream.Write($buffer, 0, $bytesRead)
+                $cryptoStream.Flush()
+            }
+            $cryptoStream.FlushFinalBlock()
+        }
+        finally {
+            if ($null -ne $cryptoStream) { $cryptoStream.Dispose() }
+            if ($null -ne $sourceStream) { $sourceStream.Dispose() }
+            if ($null -ne $encryptor) { $encryptor.Dispose() }
+        }
+
+        try {
+            $finalStream = [System.IO.File]::Open($targetFile, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::Read)
+
+            $finalStream.Seek($hmacLength, [System.IO.SeekOrigin]::Begin) > $null
+            $finalStream.Write($initializationVector, 0, $initializationVector.Length)
+            $finalStream.Seek($hmacLength, [System.IO.SeekOrigin]::Begin) > $null
+
+            $hmac = $hmacSha256.ComputeHash($finalStream)
+            $computedMac = $hmac
+
+            $finalStream.Seek(0, [System.IO.SeekOrigin]::Begin) > $null
+            $finalStream.Write($hmac, 0, $hmac.Length)
+        }
+        finally {
+            if ($null -ne $finalStream) { $finalStream.Dispose() }
+        }
+    }
+    finally {
+        if ($null -ne $targetStream) { $targetStream.Dispose() }
+        if ($null -ne $aes) { $aes.Dispose() }
+    }
+
+    $computedMac
+}
+
+####################################################
+# Function to encrypt the file and return the file encryption info needed to commit the file
+function EncryptFile($sourceFile, $targetFile) {
+
+    $encryptionKey = GenerateKey
+    $hmacKey = GenerateKey
+    $initializationVector = GenerateIV
+
+    # Create the encrypted target file and compute the HMAC value.
+    $mac = EncryptFileWithIV $sourceFile $targetFile $encryptionKey $hmacKey $initializationVector
+
+    # Compute the SHA256 hash of the source file and convert the result to bytes.
+    $fileDigest = (Get-FileHash $sourceFile -Algorithm SHA256).Hash
+    $fileDigestBytes = New-Object byte[] ($fileDigest.Length / 2)
+    for ($i = 0; $i -lt $fileDigest.Length; $i += 2) {
+        $fileDigestBytes[$i / 2] = [System.Convert]::ToByte($fileDigest.Substring($i, 2), 16)
+    }
+
+    # Return an object that will serialize correctly to the file commit Graph API.
+    $encryptionInfo = @{}
+    $encryptionInfo.encryptionKey = [System.Convert]::ToBase64String($encryptionKey)
+    $encryptionInfo.macKey = [System.Convert]::ToBase64String($hmacKey)
+    $encryptionInfo.initializationVector = [System.Convert]::ToBase64String($initializationVector)
+    $encryptionInfo.mac = [System.Convert]::ToBase64String($mac)
+    $encryptionInfo.profileIdentifier = "ProfileVersion1"
+    $encryptionInfo.fileDigest = [System.Convert]::ToBase64String($fileDigestBytes)
+    $encryptionInfo.fileDigestAlgorithm = "SHA256"
+
+    $fileEncryptionInfo = @{}
+    $fileEncryptionInfo.fileEncryptionInfo = $encryptionInfo
+
+    $fileEncryptionInfo
+}
+
+####################################################
+# Function to wait for file processing to complete by polling the file upload state
+function WaitForFileProcessing($fileUri, $stage) {
+    $attempts = 60
+    $waitTimeInSeconds = 1
+    $successState = "$($stage)Success"
+    $pendingState = "$($stage)Pending"
+
+    $file = $null
+    while ($attempts -gt 0) {
+        $file = Invoke-MgGraphRequest -Method GET -Uri $fileUri
+        if ($file.uploadState -eq $successState) {
+            break
+        }
+        elseif ($file.uploadState -ne $pendingState) {
+            throw "File upload state is not success: $($file.uploadState)"
+        }
+
+        Start-Sleep $waitTimeInSeconds
+        $attempts--
+    }
+
+    if ($null -eq $file) {
+        throw "File request did not complete in the allotted time."
+    }
+
+    $file
+}
+
+####################################################
+# Function that splits the source file into chunks and uploads them to the Azure Storage SAS URI location, then finalizes the upload
+function UploadFileToAzureStorage($sasUri, $filepath, $blockSizeMB) {
+    # Chunk size in MiB
+    $chunkSizeInBytes = (1024 * 1024 * $blockSizeMB)
+
+    # Read the whole file and find the total chunks.
+    $fileStream = [System.IO.File]::OpenRead($filepath)
+    $chunks = [Math]::Ceiling($fileStream.Length / $chunkSizeInBytes)
+
+    # Upload each chunk.
+    $ids = @()
+    $cc = 1
+    $chunk = 0
+    while ($fileStream.Position -lt $fileStream.Length) {
+        $id = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($chunk.ToString("0000")))
+        $ids += $id
+
+        $size = [Math]::Min($chunkSizeInBytes, $fileStream.Length - $fileStream.Position)
+        $body = New-Object byte[] $size
+        $fileStream.Read($body, 0, $size) > $null
+
+        Write-Progress -Activity "Uploading File to Azure Storage" -Status "Uploading chunk $cc of $chunks" -PercentComplete ($cc / $chunks * 100)
+        $cc++
+
+        UploadAzureStorageChunk $sasUri $id $body | Out-Null
+        $chunk++
+    }
+
+    $fileStream.Close()
+    Write-Progress -Completed -Activity "Uploading File to Azure Storage"
+
+    # Finalize the upload.
+    FinalizeAzureStorageUpload $sasUri $ids | Out-Null
+}
+
+####################################################
+# Function to upload a chunk to Azure Storage
+function UploadAzureStorageChunk($sasUri, $id, $body) {
+    $uri = "$sasUri&comp=block&blockid=$id"
+    $request = "PUT $uri"
+
+    $headers = @{
+        "x-ms-blob-type" = "BlockBlob"
+        "Content-Type"   = "application/octet-stream"
+    }
+
+    try {
+        Invoke-WebRequest -Headers $headers $uri -Method Put -Body $body | Out-Null
+    }
+    catch {
+        Write-Host -ForegroundColor Red $request
+        Write-Host -ForegroundColor Red $_.Exception.Message
+        throw
+    }
+}
+
+####################################################
+# Function to finalize the Azure Storage upload by joining the uploaded chunks
+function FinalizeAzureStorageUpload($sasUri, $ids) {
+    $uri = "$sasUri&comp=blocklist"
+    $request = "PUT $uri"
+
+    $xml = '<?xml version="1.0" encoding="utf-8"?><BlockList>'
+    foreach ($id in $ids) {
+        $xml += "<Latest>$id</Latest>"
+    }
+    $xml += '</BlockList>'
+
+    $headers = @{
+        "Content-Type" = "text/plain"
+    }
+
+    try {
+        Invoke-WebRequest $uri -Method Put -Body $xml -Headers $headers | Out-Null
+    }
+    catch {
+        Write-Host -ForegroundColor Red $request
+        Write-Host -ForegroundColor Red $_.Exception.Message
+        throw
+    }
+}
+
+####################################################
+# Function to create a new mobileAppContentFile body containing the file information
+function GetAppFileBody($name, $size, $sizeEncrypted, $manifest) {
+    $body = @{ "@odata.type" = "#microsoft.graph.mobileAppContentFile" }
+    $body.name = $name
+    $body.size = $size
+    $body.sizeEncrypted = $sizeEncrypted
+    $body.manifest = $manifest
+    $body.isDependency = $false
+
+    $body
+}

--- a/LOB_Application/MSIX_Application_Update.ps1
+++ b/LOB_Application/MSIX_Application_Update.ps1
@@ -1,0 +1,536 @@
+#requires -module Microsoft.Graph.Devices.CorporateManagement
+#requires -module Microsoft.Graph.Authentication
+
+<# region Authentication
+To authenticate, you'll use the Microsoft Graph PowerShell SDK. If you haven't already installed the SDK, see this guide:
+https://learn.microsoft.com/en-us/powershell/microsoftgraph/installation?view=graph-powershell-1.0
+The PowerShell SDK supports two types of authentication: delegated access, and app-only access.
+For details on using delegated access, see this guide here:
+https://learn.microsoft.com/powershell/microsoftgraph/get-started?view=graph-powershell-1.0
+For details on using app-only access for unattended scenarios, see Use app-only authentication with the Microsoft Graph PowerShell SDK:
+https://learn.microsoft.com/powershell/microsoftgraph/app-only?view=graph-powershell-1.0&tabs=azure-portal
+#>
+
+<#
+.SYNOPSIS
+Updates an MSIX/AppX line-of-business app (windowsUniversalAppX) in Intune.
+
+.DESCRIPTION
+This function updates an existing MSIX/AppX line-of-business app in Intune by uploading a new package as a
+new content version. The new .msix/.appx is encrypted locally, uploaded to Azure Storage, and committed,
+then the app is pointed at the new content version. A windowsUniversalAppX app's package identity
+(identityName, identityPublisherHash, identityVersion, isBundle, applicableArchitectures, etc.) is read-only
+after creation, so an update changes only the package content plus any editable metadata (display name,
+publisher, description, icon).
+
+Note: Intune requires that an updated windowsUniversalAppX package has the same Identity Name and Publisher
+as the existing app. Typically only the Identity Version increases between updates.
+
+.PARAMETER AppId
+The ID of the Intune windowsUniversalAppX app to update.
+
+.PARAMETER UpdateAppContentOnly
+If $true, only the app package content is updated and other app properties (e.g. Name, identity, etc.) are not updated.
+
+.PARAMETER SourceFile
+The path to the .msix, .msixbundle, .appx, or .appxbundle file.
+
+.PARAMETER displayName
+The new display name of the app. Only applied when -UpdateAppContentOnly is $false. If omitted, the existing display name is left unchanged.
+
+.PARAMETER publisher
+The new publisher of the app. Only applied when -UpdateAppContentOnly is $false. If omitted, the existing publisher is left unchanged.
+
+.PARAMETER description
+The new description of the app. Only applied when -UpdateAppContentOnly is $false. If omitted, the existing description is left unchanged.
+
+.PARAMETER minimumSupportedOperatingSystem
+The minimum supported operating system for the app, as a windowsMinimumOperatingSystem hashtable.
+Valid keys for windowsUniversalAppX are 'v8_0', 'v8_1', and 'v10_0'. Only applied when -UpdateAppContentOnly is $false and a value is supplied.
+
+.PARAMETER IconFile
+The path to an image file (.png, .jpg, .jpeg, or .gif) to use as the app icon. The image is converted to a mimeContent object and uploaded as the app's largeIcon. Optional, and applied whether or not -UpdateAppContentOnly is used.
+
+.EXAMPLE
+# Updates only the package content of an existing MSIX app.
+Invoke-MSIXAppUpdate -AppId "12345678-1234-1234-1234-123456789012" -UpdateAppContentOnly $true -SourceFile "C:\IntuneApps\Contoso\Contoso.DemoApp_1.1.0.0_x64.msix"
+
+.EXAMPLE
+# Updates the package content and app properties of an existing MSIX app.
+Invoke-MSIXAppUpdate -AppId "12345678-1234-1234-1234-123456789012" -UpdateAppContentOnly $false -SourceFile "C:\IntuneApps\Contoso\Contoso.DemoApp_1.1.0.0_x64.msix" -displayName "Contoso Demo App" -publisher "Contoso" -description "Version 1.1.0.0"
+
+.EXAMPLE
+# Updates only the app icon of an existing MSIX app (still requires a source package for the new content version).
+Invoke-MSIXAppUpdate -AppId "12345678-1234-1234-1234-123456789012" -UpdateAppContentOnly $true -SourceFile "C:\IntuneApps\Contoso\Contoso.DemoApp_1.0.0.0_x64.msix" -IconFile "C:\IntuneApps\Contoso\icon.png"
+#>
+function Invoke-MSIXAppUpdate {
+    [cmdletbinding()]
+    param
+    (
+        [parameter(Mandatory = $true, Position = 1)]
+        [ValidateNotNullOrEmpty()]
+        [string]$AppId,
+
+        [parameter(Mandatory = $true, Position = 2)]
+        [bool]$UpdateAppContentOnly,
+
+        [parameter(Mandatory = $true, Position = 3)]
+        [ValidateNotNullOrEmpty()]
+        [string]$SourceFile,
+
+        [parameter(Mandatory = $false, Position = 4)]
+        [string]$displayName,
+
+        [parameter(Mandatory = $false, Position = 5)]
+        [string]$publisher,
+
+        [parameter(Mandatory = $false, Position = 6)]
+        [string]$description,
+
+        [parameter(Mandatory = $false, Position = 7)]
+        [hashtable]$minimumSupportedOperatingSystem,
+
+        [parameter(Mandatory = $false, Position = 8)]
+        [string]$IconFile
+    )
+
+    # Temp encrypted copy of the package (created during the encryption step, removed in the finally block)
+    $tempFile = $null
+
+    try {
+        # Check if the app exists
+        $MobileApp = Get-MgDeviceAppManagementMobileApp -MobileAppId $AppId
+
+        if ($null -eq $MobileApp) {
+            Write-Host "Application with ID '$AppId' does not exist in Intune." -ForegroundColor Red
+            break
+        }
+
+        Write-Host "Application found..." -ForegroundColor Yellow
+        $mobileAppId = $MobileApp.id
+
+        # Check if the source file exists and has a supported extension
+        Write-Host "Testing if SourceFile '$SourceFile' Path is valid..." -ForegroundColor Yellow
+        Test-SourceFile "$SourceFile"
+
+        $Ext = [System.IO.Path]::GetExtension("$SourceFile").ToLower()
+        if ($Ext -notin '.msix', '.msixbundle', '.appx', '.appxbundle') {
+            throw "Unsupported file type '$Ext'. Supported types are .msix, .msixbundle, .appx, and .appxbundle."
+        }
+
+        $FileName = [System.IO.Path]::GetFileName("$SourceFile")
+
+        # Note: a windowsUniversalAppX app's package identity (identityName, identityPublisherHash,
+        # identityVersion, isBundle, applicableArchitectures, etc.) is read-only after creation - the
+        # service re-derives it from the newly committed package content. An update therefore only changes
+        # the package content plus any editable metadata (display name, publisher, description, icon).
+
+        # Create a new content version for the application
+        Write-Host "Creating Content Version in the service for the updated application..." -ForegroundColor Yellow
+        $ContentVersion = New-MgDeviceAppManagementMobileAppAsWindowsUniversalAppXContentVersion -MobileAppId $mobileAppId -BodyParameter @{}
+        $ContentVersionId = $ContentVersion.id
+
+        # Encrypt a copy of the package. Unlike a .intunewin file (which is already encrypted), the .msix is
+        # a raw file, so the script generates the encryption keys and computes the file digest itself.
+        Write-Host "Encrypting a copy of the package '$SourceFile'..." -ForegroundColor Yellow
+        $tempFile = [System.IO.Path]::Combine([System.IO.Path]::GetDirectoryName("$SourceFile"), [System.IO.Path]::GetFileNameWithoutExtension("$SourceFile") + "_" + [guid]::NewGuid().ToString() + "_temp.bin")
+        $fileEncryptionInfo = EncryptFile "$SourceFile" "$tempFile"
+
+        [int64]$Size = (Get-Item "$SourceFile").Length
+        $EncrySize = (Get-Item "$tempFile").Length
+
+        # Create a new file entry in Azure for the upload. Unlike Win32/macOS content files, a
+        # windowsUniversalAppX content file requires a (non-null) manifest. For MSIX/AppX the service only
+        # requires the base64-encoded file name here (the rich identity metadata is supplied on the app body).
+        $encodedManifest = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($FileName))
+        $fileBody = GetAppFileBody "$FileName" $Size $EncrySize $encodedManifest
+        Write-Host "Creating a new file entry in Azure for the upload..." -ForegroundColor Yellow
+        $ContentVersionFile = New-MgDeviceAppManagementMobileAppAsWindowsUniversalAppXContentVersionFile -MobileAppId $mobileAppId -MobileAppContentId $ContentVersionId -BodyParameter ($fileBody | ConvertTo-Json)
+        $ContentVersionFileId = $ContentVersionFile.id
+
+        # Get the file URI for the upload
+        $fileUri = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$mobileAppId/microsoft.graph.windowsUniversalAppX/contentVersions/$ContentVersionId/files/$ContentVersionFileId"
+
+        # Wait for the Azure Storage SAS URI to be created
+        Write-Host "Waiting for the file entry SAS URI to be created..." -ForegroundColor Yellow
+        $file = WaitForFileProcessing $fileUri "AzureStorageUriRequest"
+
+        # Upload the encrypted file to Azure Storage
+        Write-Host "Uploading the file to Azure Storage..." -ForegroundColor Yellow
+        [UInt64]$BlockSizeMB = 4
+        UploadFileToAzureStorage $file.azureStorageUri "$tempFile" $BlockSizeMB
+
+        # Commit the file to the service using the encryption information
+        Write-Host "Committing the file to the service..." -ForegroundColor Yellow
+        Start-Sleep -Seconds 5
+        Invoke-MgCommitDeviceAppManagementMobileAppMicrosoftGraphWindowsUniversalAppXContentVersionFile -MobileAppId $mobileAppId -MobileAppContentId $ContentVersionId -MobileAppContentFileId $ContentVersionFileId -BodyParameter ($fileEncryptionInfo | ConvertTo-Json)
+
+        # Wait for the file to be processed
+        Write-Host "Waiting for the file to be processed..." -ForegroundColor Yellow
+        $file = WaitForFileProcessing $fileUri "CommitFile"
+
+        # Build the body that points the app at the new committed content version. Only editable metadata is
+        # included; the package identity is read-only and is re-derived from the committed content. Editable
+        # fields are set only when supplied so an update never overwrites the existing display name,
+        # publisher, or description with values that were not requested.
+        $params = @{
+            "@odata.type"           = "#microsoft.graph.windowsUniversalAppX"
+            committedContentVersion = "$ContentVersionId"
+        }
+
+        if (-not $UpdateAppContentOnly) {
+            if ($displayName) { $params.displayName = $displayName }
+            if ($publisher) { $params.publisher = $publisher }
+            if ($description) { $params.description = $description }
+            if ($minimumSupportedOperatingSystem) { $params.minimumSupportedOperatingSystem = $minimumSupportedOperatingSystem }
+        }
+
+        # Add the app icon (largeIcon) if an icon file was provided
+        if ($IconFile) {
+            Write-Host "Adding app icon from '$IconFile'..." -ForegroundColor Yellow
+            $params["largeIcon"] = New-IntuneAppIcon -IconFile $IconFile
+        }
+
+        # Update the application with the new content version
+        Write-Host "Updating the application with the new content version..." -ForegroundColor Yellow
+        Update-MgDeviceAppManagementMobileApp -MobileAppId $mobileAppId -BodyParameter ($params | ConvertTo-Json)
+
+        # Return the application details
+        Write-Host "Application updated successfully:" -ForegroundColor Green
+        Get-MgDeviceAppManagementMobileApp -MobileAppId $mobileAppId | Format-List
+    }
+    catch {
+        Write-Host -ForegroundColor Red "Aborting with exception: $($_.Exception.ToString())"
+        break
+    }
+    finally {
+        # Clean up the temporary encrypted copy of the package
+        if ($tempFile -and (Test-Path "$tempFile")) {
+            Remove-Item -Path "$tempFile" -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+Converts an image file to a mimeContent object for use as an app icon.
+
+.DESCRIPTION
+This function reads an image file from disk, base64-encodes its content, and returns a mimeContent hashtable that can be assigned to a mobileApp's largeIcon property. Supported image types are .png, .jpg, .jpeg, and .gif.
+
+.PARAMETER IconFile
+The path to the image file to use as the app icon.
+
+.EXAMPLE
+# Creates a mimeContent icon object from a .png file.
+New-IntuneAppIcon -IconFile "C:\IntuneApps\Contoso\icon.png"
+#>
+function New-IntuneAppIcon() {
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$IconFile
+    )
+
+    # Check the icon file exists
+    if (!(Test-Path "$IconFile")) {
+        Write-Host "Icon file '$IconFile' doesn't exist..." -ForegroundColor Red
+        throw "Icon file not found: $IconFile"
+    }
+
+    # Determine the MIME type from the file extension
+    $Extension = [System.IO.Path]::GetExtension("$IconFile").ToLower()
+    switch ($Extension) {
+        ".png" { $MimeType = "image/png" }
+        ".jpg" { $MimeType = "image/jpeg" }
+        ".jpeg" { $MimeType = "image/jpeg" }
+        ".gif" { $MimeType = "image/gif" }
+        default {
+            Write-Host "Unsupported icon file type '$Extension'. Supported types are .png, .jpg, .jpeg, and .gif." -ForegroundColor Red
+            throw "Unsupported icon file type: $Extension"
+        }
+    }
+
+    # Read the image file and base64-encode its content
+    $IconContent = [System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$IconFile"))
+
+    # Construct and return the mimeContent object (used as the app's largeIcon)
+    $Icon = @{
+        "@odata.type" = "#microsoft.graph.mimeContent"
+        "type"        = $MimeType
+        "value"       = $IconContent
+    }
+
+    return $Icon
+}
+
+####################################################
+# Function to test if the source file exists
+Function Test-SourceFile() {
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        $SourceFile
+    )
+    try {
+        if (!(Test-Path "$SourceFile")) {
+            Write-Host
+            Write-Host "Source File '$SourceFile' doesn't exist..." -ForegroundColor Red
+            throw
+        }
+    }
+    catch {
+        Write-Host -ForegroundColor Red $_.Exception.Message
+        Write-Host
+        break
+    }
+}
+
+####################################################
+# Function to generate the AES encryption key
+function GenerateKey {
+    try {
+        $aes = [System.Security.Cryptography.Aes]::Create()
+        $aesProvider = New-Object System.Security.Cryptography.AesCryptoServiceProvider
+        $aesProvider.GenerateKey()
+        $aesProvider.Key
+    }
+    finally {
+        if ($null -ne $aesProvider) { $aesProvider.Dispose() }
+        if ($null -ne $aes) { $aes.Dispose() }
+    }
+}
+
+####################################################
+# Function to generate the AES initialization vector
+function GenerateIV {
+    try {
+        $aes = [System.Security.Cryptography.Aes]::Create()
+        $aes.IV
+    }
+    finally {
+        if ($null -ne $aes) { $aes.Dispose() }
+    }
+}
+
+####################################################
+# Function to create the encrypted target file, compute the HMAC value, and return the HMAC value
+function EncryptFileWithIV($sourceFile, $targetFile, $encryptionKey, $hmacKey, $initializationVector) {
+    $bufferBlockSize = 1024 * 4
+    $computedMac = $null
+
+    try {
+        $aes = [System.Security.Cryptography.Aes]::Create()
+        $hmacSha256 = New-Object System.Security.Cryptography.HMACSHA256
+        $hmacSha256.Key = $hmacKey
+        $hmacLength = $hmacSha256.HashSize / 8
+
+        $buffer = New-Object byte[] $bufferBlockSize
+        $bytesRead = 0
+
+        $targetStream = [System.IO.File]::Open($targetFile, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::Read)
+        $targetStream.Write($buffer, 0, $hmacLength + $initializationVector.Length)
+
+        try {
+            $encryptor = $aes.CreateEncryptor($encryptionKey, $initializationVector)
+            $sourceStream = [System.IO.File]::Open($sourceFile, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::Read)
+            $cryptoStream = New-Object System.Security.Cryptography.CryptoStream -ArgumentList @($targetStream, $encryptor, [System.Security.Cryptography.CryptoStreamMode]::Write)
+
+            $targetStream = $null
+            while (($bytesRead = $sourceStream.Read($buffer, 0, $bufferBlockSize)) -gt 0) {
+                $cryptoStream.Write($buffer, 0, $bytesRead)
+                $cryptoStream.Flush()
+            }
+            $cryptoStream.FlushFinalBlock()
+        }
+        finally {
+            if ($null -ne $cryptoStream) { $cryptoStream.Dispose() }
+            if ($null -ne $sourceStream) { $sourceStream.Dispose() }
+            if ($null -ne $encryptor) { $encryptor.Dispose() }
+        }
+
+        try {
+            $finalStream = [System.IO.File]::Open($targetFile, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::Read)
+
+            $finalStream.Seek($hmacLength, [System.IO.SeekOrigin]::Begin) > $null
+            $finalStream.Write($initializationVector, 0, $initializationVector.Length)
+            $finalStream.Seek($hmacLength, [System.IO.SeekOrigin]::Begin) > $null
+
+            $hmac = $hmacSha256.ComputeHash($finalStream)
+            $computedMac = $hmac
+
+            $finalStream.Seek(0, [System.IO.SeekOrigin]::Begin) > $null
+            $finalStream.Write($hmac, 0, $hmac.Length)
+        }
+        finally {
+            if ($null -ne $finalStream) { $finalStream.Dispose() }
+        }
+    }
+    finally {
+        if ($null -ne $targetStream) { $targetStream.Dispose() }
+        if ($null -ne $aes) { $aes.Dispose() }
+    }
+
+    $computedMac
+}
+
+####################################################
+# Function to encrypt the file and return the file encryption info needed to commit the file
+function EncryptFile($sourceFile, $targetFile) {
+
+    $encryptionKey = GenerateKey
+    $hmacKey = GenerateKey
+    $initializationVector = GenerateIV
+
+    # Create the encrypted target file and compute the HMAC value.
+    $mac = EncryptFileWithIV $sourceFile $targetFile $encryptionKey $hmacKey $initializationVector
+
+    # Compute the SHA256 hash of the source file and convert the result to bytes.
+    $fileDigest = (Get-FileHash $sourceFile -Algorithm SHA256).Hash
+    $fileDigestBytes = New-Object byte[] ($fileDigest.Length / 2)
+    for ($i = 0; $i -lt $fileDigest.Length; $i += 2) {
+        $fileDigestBytes[$i / 2] = [System.Convert]::ToByte($fileDigest.Substring($i, 2), 16)
+    }
+
+    # Return an object that will serialize correctly to the file commit Graph API.
+    $encryptionInfo = @{}
+    $encryptionInfo.encryptionKey = [System.Convert]::ToBase64String($encryptionKey)
+    $encryptionInfo.macKey = [System.Convert]::ToBase64String($hmacKey)
+    $encryptionInfo.initializationVector = [System.Convert]::ToBase64String($initializationVector)
+    $encryptionInfo.mac = [System.Convert]::ToBase64String($mac)
+    $encryptionInfo.profileIdentifier = "ProfileVersion1"
+    $encryptionInfo.fileDigest = [System.Convert]::ToBase64String($fileDigestBytes)
+    $encryptionInfo.fileDigestAlgorithm = "SHA256"
+
+    $fileEncryptionInfo = @{}
+    $fileEncryptionInfo.fileEncryptionInfo = $encryptionInfo
+
+    $fileEncryptionInfo
+}
+
+####################################################
+# Function to wait for file processing to complete by polling the file upload state
+function WaitForFileProcessing($fileUri, $stage) {
+    $attempts = 60
+    $waitTimeInSeconds = 1
+    $successState = "$($stage)Success"
+    $pendingState = "$($stage)Pending"
+
+    $file = $null
+    while ($attempts -gt 0) {
+        $file = Invoke-MgGraphRequest -Method GET -Uri $fileUri
+        if ($file.uploadState -eq $successState) {
+            break
+        }
+        elseif ($file.uploadState -ne $pendingState) {
+            throw "File upload state is not success: $($file.uploadState)"
+        }
+
+        Start-Sleep $waitTimeInSeconds
+        $attempts--
+    }
+
+    if ($null -eq $file) {
+        throw "File request did not complete in the allotted time."
+    }
+
+    $file
+}
+
+####################################################
+# Function that splits the source file into chunks and uploads them to the Azure Storage SAS URI location, then finalizes the upload
+function UploadFileToAzureStorage($sasUri, $filepath, $blockSizeMB) {
+    # Chunk size in MiB
+    $chunkSizeInBytes = (1024 * 1024 * $blockSizeMB)
+
+    # Read the whole file and find the total chunks.
+    $fileStream = [System.IO.File]::OpenRead($filepath)
+    $chunks = [Math]::Ceiling($fileStream.Length / $chunkSizeInBytes)
+
+    # Upload each chunk.
+    $ids = @()
+    $cc = 1
+    $chunk = 0
+    while ($fileStream.Position -lt $fileStream.Length) {
+        $id = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($chunk.ToString("0000")))
+        $ids += $id
+
+        $size = [Math]::Min($chunkSizeInBytes, $fileStream.Length - $fileStream.Position)
+        $body = New-Object byte[] $size
+        $fileStream.Read($body, 0, $size) > $null
+
+        Write-Progress -Activity "Uploading File to Azure Storage" -Status "Uploading chunk $cc of $chunks" -PercentComplete ($cc / $chunks * 100)
+        $cc++
+
+        UploadAzureStorageChunk $sasUri $id $body | Out-Null
+        $chunk++
+    }
+
+    $fileStream.Close()
+    Write-Progress -Completed -Activity "Uploading File to Azure Storage"
+
+    # Finalize the upload.
+    FinalizeAzureStorageUpload $sasUri $ids | Out-Null
+}
+
+####################################################
+# Function to upload a chunk to Azure Storage
+function UploadAzureStorageChunk($sasUri, $id, $body) {
+    $uri = "$sasUri&comp=block&blockid=$id"
+    $request = "PUT $uri"
+
+    $headers = @{
+        "x-ms-blob-type" = "BlockBlob"
+        "Content-Type"   = "application/octet-stream"
+    }
+
+    try {
+        Invoke-WebRequest -Headers $headers $uri -Method Put -Body $body | Out-Null
+    }
+    catch {
+        Write-Host -ForegroundColor Red $request
+        Write-Host -ForegroundColor Red $_.Exception.Message
+        throw
+    }
+}
+
+####################################################
+# Function to finalize the Azure Storage upload by joining the uploaded chunks
+function FinalizeAzureStorageUpload($sasUri, $ids) {
+    $uri = "$sasUri&comp=blocklist"
+    $request = "PUT $uri"
+
+    $xml = '<?xml version="1.0" encoding="utf-8"?><BlockList>'
+    foreach ($id in $ids) {
+        $xml += "<Latest>$id</Latest>"
+    }
+    $xml += '</BlockList>'
+
+    $headers = @{
+        "Content-Type" = "text/plain"
+    }
+
+    try {
+        Invoke-WebRequest $uri -Method Put -Body $xml -Headers $headers | Out-Null
+    }
+    catch {
+        Write-Host -ForegroundColor Red $request
+        Write-Host -ForegroundColor Red $_.Exception.Message
+        throw
+    }
+}
+
+####################################################
+# Function to create a new mobileAppContentFile body containing the file information
+function GetAppFileBody($name, $size, $sizeEncrypted, $manifest) {
+    $body = @{ "@odata.type" = "#microsoft.graph.mobileAppContentFile" }
+    $body.name = $name
+    $body.size = $size
+    $body.sizeEncrypted = $sizeEncrypted
+    $body.manifest = $manifest
+    $body.isDependency = $false
+
+    $body
+}

--- a/LOB_Application/Win32_Application_Add.ps1
+++ b/LOB_Application/Win32_Application_Add.ps1
@@ -48,6 +48,9 @@ The account to run the app as. Valid values are 'system' or 'user'.
 .PARAMETER DeviceRestartBehavior
 The device restart behavior for the app. Valid values are 'basedOnReturnCode', 'allow', 'suppress', 'force'.
 
+.PARAMETER IconFile
+The path to an image file (.png, .jpg, .jpeg, or .gif) to use as the app icon. The image is converted to a mimeContent object and uploaded as the app's largeIcon. Optional.
+
 .EXAMPLE
 # Uploads a .exe Win32 app to Intune using the default return codes and a file system rule.
 $returnCodes = Get-DefaultReturnCodes
@@ -112,7 +115,10 @@ function Invoke-Win32AppUpload {
 
         [parameter(Mandatory = $true, Position = 11)]
         [ValidateSet('basedOnReturnCode', 'allow', 'suppress', 'force')]
-        [string]$DeviceRestartBehavior
+        [string]$DeviceRestartBehavior,
+
+        [parameter(Mandatory = $false, Position = 12)]
+        [string]$IconFile
     )
     try	{
 
@@ -195,6 +201,12 @@ function Invoke-Win32AppUpload {
             Write-Warning "Intunewin file requires ReturnCodes to be specified"
             Write-Warning "If you want to use the default ReturnCode run 'Get-DefaultReturnCodes'"
             break
+        }
+
+        # Add the app icon (largeIcon) if an icon file was provided
+        if ($IconFile) {
+            Write-Host "Adding app icon from '$IconFile'..." -ForegroundColor Yellow
+            $mobileAppBody.Add("largeIcon", (New-IntuneAppIcon -IconFile $IconFile))
         }
 
         # Create the application in Intune and get the application ID
@@ -675,6 +687,60 @@ function New-ReturnCode() {
     )
 
     @{"returnCode" = $returnCode; "type" = "$type" }
+}
+
+<#
+.SYNOPSIS
+Converts an image file to a mimeContent object for use as a Win32 app icon.
+
+.DESCRIPTION
+This function reads an image file from disk, base64-encodes its content, and returns a mimeContent hashtable that can be assigned to a mobileApp's largeIcon property. Supported image types are .png, .jpg, .jpeg, and .gif.
+
+.PARAMETER IconFile
+The path to the image file to use as the app icon.
+
+.EXAMPLE
+# Creates a mimeContent icon object from a .png file.
+New-IntuneAppIcon -IconFile "C:\IntuneApps\vscode\icon.png"
+#>
+function New-IntuneAppIcon() {
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$IconFile
+    )
+
+    # Check the icon file exists
+    if (!(Test-Path "$IconFile")) {
+        Write-Host "Icon file '$IconFile' doesn't exist..." -ForegroundColor Red
+        throw "Icon file not found: $IconFile"
+    }
+
+    # Determine the MIME type from the file extension
+    $Extension = [System.IO.Path]::GetExtension("$IconFile").ToLower()
+    switch ($Extension) {
+        ".png" { $MimeType = "image/png" }
+        ".jpg" { $MimeType = "image/jpeg" }
+        ".jpeg" { $MimeType = "image/jpeg" }
+        ".gif" { $MimeType = "image/gif" }
+        default {
+            Write-Host "Unsupported icon file type '$Extension'. Supported types are .png, .jpg, .jpeg, and .gif." -ForegroundColor Red
+            throw "Unsupported icon file type: $Extension"
+        }
+    }
+
+    # Read the image file and base64-encode its content
+    $IconContent = [System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$IconFile"))
+
+    # Construct and return the mimeContent object (used as the app's largeIcon)
+    $Icon = @{
+        "@odata.type" = "#microsoft.graph.mimeContent"
+        "type"        = $MimeType
+        "value"       = $IconContent
+    }
+
+    return $Icon
 }
 
 ####################################################

--- a/LOB_Application/Win32_Application_Update.ps1
+++ b/LOB_Application/Win32_Application_Update.ps1
@@ -54,6 +54,9 @@ The account to run the app as. Valid values are 'system' or 'user'.
 .PARAMETER DeviceRestartBehavior
 The device restart behavior for the app. Valid values are 'basedOnReturnCode', 'allow', 'suppress', 'force'.
 
+.PARAMETER IconFile
+The path to an image file (.png, .jpg, .jpeg, or .gif) to use as the app icon. The image is converted to a mimeContent object and uploaded as the app's largeIcon. Optional, and applied whether or not -UpdateAppContentOnly is used.
+
 .EXAMPLE
 # Updates a .exe Win32 app in Intune (only the app package content).
 Invoke-Win32AppUpdate -AppId "12345678-1234-1234-1234-123456789012" -UpdateAppContentOnly -SourceFile "C:\IntuneApps\vscode\VSCodeSetup-x64-1.93.1.intunewin"
@@ -109,7 +112,10 @@ function Invoke-Win32AppUpdate {
 
 		[parameter(Mandatory = $false, Position = 12)]
 		[ValidateSet('basedOnReturnCode', 'allow', 'suppress', 'force')]
-		[string]$DeviceRestartBehavior
+		[string]$DeviceRestartBehavior,
+
+		[parameter(Mandatory = $false, Position = 13)]
+		[string]$IconFile
 	)
 	try	{
 		#Check if the app exists
@@ -280,6 +286,12 @@ function Invoke-Win32AppUpdate {
 		else {
 			$params = $mobileAppBody
 			$params.committedContentVersion = "$ContentVersionId"
+		}
+
+		# Add the app icon (largeIcon) if an icon file was provided
+		if ($IconFile) {
+			Write-Host "Adding app icon from '$IconFile'..." -ForegroundColor Yellow
+			$params["largeIcon"] = New-IntuneAppIcon -IconFile $IconFile
 		}
 
 		$params = $params | ConvertTo-Json
@@ -683,6 +695,60 @@ function New-ReturnCode() {
 	)
 
 	@{"returnCode" = $returnCode; "type" = "$type" }
+}
+
+<#
+.SYNOPSIS
+Converts an image file to a mimeContent object for use as a Win32 app icon.
+
+.DESCRIPTION
+This function reads an image file from disk, base64-encodes its content, and returns a mimeContent hashtable that can be assigned to a mobileApp's largeIcon property. Supported image types are .png, .jpg, .jpeg, and .gif.
+
+.PARAMETER IconFile
+The path to the image file to use as the app icon.
+
+.EXAMPLE
+# Creates a mimeContent icon object from a .png file.
+New-IntuneAppIcon -IconFile "C:\IntuneApps\vscode\icon.png"
+#>
+function New-IntuneAppIcon() {
+	param
+	(
+		[parameter(Mandatory = $true)]
+		[ValidateNotNullOrEmpty()]
+		[string]$IconFile
+	)
+
+	# Check the icon file exists
+	if (!(Test-Path "$IconFile")) {
+		Write-Host "Icon file '$IconFile' doesn't exist..." -ForegroundColor Red
+		throw "Icon file not found: $IconFile"
+	}
+
+	# Determine the MIME type from the file extension
+	$Extension = [System.IO.Path]::GetExtension("$IconFile").ToLower()
+	switch ($Extension) {
+		".png" { $MimeType = "image/png" }
+		".jpg" { $MimeType = "image/jpeg" }
+		".jpeg" { $MimeType = "image/jpeg" }
+		".gif" { $MimeType = "image/gif" }
+		default {
+			Write-Host "Unsupported icon file type '$Extension'. Supported types are .png, .jpg, .jpeg, and .gif." -ForegroundColor Red
+			throw "Unsupported icon file type: $Extension"
+		}
+	}
+
+	# Read the image file and base64-encode its content
+	$IconContent = [System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$IconFile"))
+
+	# Construct and return the mimeContent object (used as the app's largeIcon)
+	$Icon = @{
+		"@odata.type" = "#microsoft.graph.mimeContent"
+		"type"        = $MimeType
+		"value"       = $IconContent
+	}
+
+	return $Icon
 }
 
 ####################################################

--- a/LOB_Application/readme.md
+++ b/LOB_Application/readme.md
@@ -438,3 +438,80 @@ An example of this is below:
 # macOS Application Upload
 Invoke-macOSLobAppUpload -SourceFile "E:\CompanyPortal-Installer.pkg" -displayName "Company Portal" -Publisher "Microsoft" -Description "Company Portal for macOS" -primaryBundleId "com.microsoft.com.microsoft.CompanyPortalMac" -primaryBundleVersion "5.2409.1" -includedApps $includedApps -minimumSupportedOperatingSystem @{v10_13 = $true } -ignoreVersionDetection $true -preInstallScriptPath "E:\preInstall.sh" -postInstallScriptPath "E:\postInstall.sh"
 ```
+
+### 5. MSIX_Application_Add.ps1
+The following script sample provides the ability to upload an MSIX/AppX line-of-business application (`windowsUniversalAppX`) to the Intune Service. It supports `.msix`, `.msixbundle`, `.appx`, and `.appxbundle` packages.
+
+### Prerequisites
++ Dependent PowerShell modules:
+    - Microsoft.Graph.Devices.CorporateManagement
+    - Microsoft.Graph.Authentication
++ An MSIX/AppX package (`.msix`, `.msixbundle`, `.appx`, or `.appxbundle`)
+
+### How an MSIX app differs from a Win32 (.intunewin) app
+Unlike a Win32 `.intunewin` file, an `.msix`/`.appx` package is **not** pre-encrypted and does **not** contain a `detection.xml`. The metadata Intune needs is parsed from the package manifest instead, and the script encrypts the package itself. Specifically, the script:
+
+1. Opens the package (an `.msix`/`.appx` is a ZIP archive) and reads `AppxManifest.xml` (or `AppxBundleManifest.xml` for `.msixbundle`/`.appxbundle`).
+2. Parses the package **Identity** to populate the `windowsUniversalAppX` properties:
+    + `identityName` — `Identity/@Name`
+    + `identityVersion` — `Identity/@Version`
+    + `identityPublisherHash` — computed from `Identity/@Publisher` (see below)
+    + `identityResourceIdentifier` — `Identity/@ResourceId` (when present)
+    + `applicableArchitectures` — mapped from `Identity/@ProcessorArchitecture` (for a bundle, the distinct architectures of the contained packages)
+    + `isBundle` — `$true` for `.msixbundle`/`.appxbundle`
+3. Computes the **Identity Publisher Hash** — the same hash that forms the last segment of a package family name (for example, the `8wekyb3d8bbwe` in a Microsoft package family name). It is the Crockford-style Base32 encoding of the first 8 bytes of the SHA-256 hash of the UTF-16LE publisher string.
+4. Encrypts a copy of the package (AES + HMAC-SHA256) and uploads the encrypted copy to Azure Storage. The content file's `manifest` is set to the base64-encoded file name, which `windowsUniversalAppX` content files require.
+
+### Running the script
+1. Run the script in an IDE such as VS Code:
+####
+```PowerShell
+.\MSIX_Application_Add.ps1
+```
+
+2. To upload an MSIX/AppX app, run the `Invoke-MSIXAppUpload` function specifying at minimum the package path (`-SourceFile`). If `-displayName`, `-publisher`, or `-description` are omitted, they are taken from the package manifest.
+```PowerShell
+# Uploads an .msix app, parsing the display name, publisher, and identity from the package.
+Invoke-MSIXAppUpload -SourceFile "C:\IntuneApps\Contoso\Contoso.DemoApp_1.0.0.0_x64.msix"
+```
+
+```PowerShell
+# Uploads an .msix app with an explicit display name, publisher, description, and app icon.
+Invoke-MSIXAppUpload -SourceFile "C:\IntuneApps\Contoso\Contoso.DemoApp_1.0.0.0_x64.msix" -displayName "Contoso Demo App" -publisher "Contoso" -description "Contoso Demo App (MSIX)" -IconFile "C:\IntuneApps\Contoso\icon.png"
+```
+
+3. If successful, the script returns the application information from Intune (`@odata.type` of `#microsoft.graph.windowsUniversalAppX`, `PublishingState` of `published`).
+
+### Script parameters
++ SourceFile - The path to the `.msix`, `.msixbundle`, `.appx`, or `.appxbundle` file (required)
++ displayName - The display name of the application. Defaults to the package DisplayName (or Identity Name)
++ publisher - The publisher of the application. Defaults to the package PublisherDisplayName (or Identity Publisher)
++ description - The description of the application. Defaults to the display name
++ minimumSupportedOperatingSystem - A windowsMinimumOperatingSystem hashtable. Valid keys are `v8_0`, `v8_1`, and `v10_0`. Defaults to `@{ v10_0 = $true }`
++ IconFile - The path to a `.png`, `.jpg`, `.jpeg`, or `.gif` image to use as the app icon (optional)
+
+> **Note on app icons:** the icon's MIME type is determined from the file extension. Make sure the file content matches its extension — for example, a WebP image saved with a `.png` extension is rejected by Intune with `Icon in invalid format`.
+
+### 6. MSIX_Application_Update.ps1
+The following script sample provides the ability to update an existing MSIX/AppX application (`windowsUniversalAppX`) in Intune by uploading a new package as a new content version.
+
+A `windowsUniversalAppX` app's package identity (`identityName`, `identityPublisherHash`, `identityVersion`, `isBundle`, `applicableArchitectures`, etc.) is **read-only after creation** — the service re-derives it from the newly committed package content. An update therefore changes only the package content plus any editable metadata (display name, publisher, description, icon). The replacement package must have the same Identity Name and Publisher as the existing app; normally only the Identity Version increases between updates.
+
+### Running the script
+1. Run the script in an IDE such as VS Code:
+####
+```PowerShell
+.\MSIX_Application_Update.ps1
+```
+
+2. To update only the package content, specify the `-AppId` and set `-UpdateAppContentOnly` to `$true`.
+```PowerShell
+Invoke-MSIXAppUpdate -AppId "12345678-1234-1234-1234-123456789012" -UpdateAppContentOnly $true -SourceFile "C:\IntuneApps\Contoso\Contoso.DemoApp_1.1.0.0_x64.msix"
+```
+
+3. To update the package content and editable app properties, set `-UpdateAppContentOnly` to `$false` and supply the properties to change. Properties that are omitted are left unchanged.
+```PowerShell
+Invoke-MSIXAppUpdate -AppId "12345678-1234-1234-1234-123456789012" -UpdateAppContentOnly $false -SourceFile "C:\IntuneApps\Contoso\Contoso.DemoApp_1.1.0.0_x64.msix" -description "Version 1.1.0.0" -IconFile "C:\IntuneApps\Contoso\icon.png"
+```
+
+4. If successful, the script returns the updated application information from Intune (with an incremented `committedContentVersion`).


### PR DESCRIPTION
This pull request adds support for specifying a custom app icon when uploading or updating Win32 and MSIX applications in Intune using the provided PowerShell scripts. A new parameter, `IconFile`, allows users to provide a `.png`, `.jpg`, `.jpeg`, or `.gif` image, which is converted to the required format and uploaded as the app's large icon. Additionally, the documentation is updated to reflect these changes and to provide guidance for MSIX application scripts.

**Win32 and MSIX Application Icon Support**

* Added an `IconFile` parameter to both `Invoke-Win32AppUpload` and `Invoke-Win32AppUpdate` functions, allowing users to specify an image file to be used as the app's icon. The image is converted and uploaded as the app's `largeIcon` property if provided. [[1]](diffhunk://#diff-6008354b1f1dd2f8f373721813fb75f9aa125c40eacf3d5fea9ffbf02784c8c7R51-R53) [[2]](diffhunk://#diff-6008354b1f1dd2f8f373721813fb75f9aa125c40eacf3d5fea9ffbf02784c8c7L115-R121) [[3]](diffhunk://#diff-6008354b1f1dd2f8f373721813fb75f9aa125c40eacf3d5fea9ffbf02784c8c7R206-R211) [[4]](diffhunk://#diff-6c7814613ea87cc423324f161e92555f6b3ec13ad1e8d44e1eab9658623f4d62R57-R59) [[5]](diffhunk://#diff-6c7814613ea87cc423324f161e92555f6b3ec13ad1e8d44e1eab9658623f4d62L112-R118) [[6]](diffhunk://#diff-6c7814613ea87cc423324f161e92555f6b3ec13ad1e8d44e1eab9658623f4d62R291-R296)
* Introduced a new helper function, `New-IntuneAppIcon`, which validates the image file, determines its MIME type, base64-encodes its content, and returns a mimeContent object suitable for the Intune API. [[1]](diffhunk://#diff-6008354b1f1dd2f8f373721813fb75f9aa125c40eacf3d5fea9ffbf02784c8c7R692-R745) [[2]](diffhunk://#diff-6c7814613ea87cc423324f161e92555f6b3ec13ad1e8d44e1eab9658623f4d62R700-R753)

**Documentation Updates**

* Updated `readme.md` to include detailed instructions and examples for uploading and updating MSIX applications, including the use of the new `IconFile` parameter and notes on supported image types.

These enhancements make it easier to assign custom icons to apps during both initial upload and updates, improving the user experience and consistency across application types.